### PR TITLE
BEL-899 Add cname to cloudflare

### DIFF
--- a/.github/workflows/rails-deploy.yml
+++ b/.github/workflows/rails-deploy.yml
@@ -39,6 +39,7 @@ jobs:
         PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
         CONTAINER_IMAGE: ${{ inputs.container-image }}
         RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
         ENVIRONMENT_NAME: ${{ inputs.environment-name }}
       run: |
         cd ./infrastructure/

--- a/deployment/requirements.txt
+++ b/deployment/requirements.txt
@@ -1,6 +1,7 @@
 pulumi
 pulumi-aws
 pulumi-awsx
+pulumi_cloudflare
 pulumi-random
 
 pytest-describe

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -37,8 +37,6 @@ class RailsComponent(pulumi.ComponentResource):
 
         self.security()
 
-        self.dns(project)
-
         self.register_outputs({})
 
     def security(self):
@@ -117,24 +115,3 @@ class RailsComponent(pulumi.ComponentResource):
                              '@',
                              self.rds_serverless_cluster.endpoint,
                              ':5432/app')
-
-    def dns(self, name):
-        if self.env_name != "prod":
-            name = f"{self.env_name}-{name}"
-        domain = 'strongmind.com'
-        zone_id = self.kwargs.get('zone_id')
-        if not zone_id:  # pragma: no cover
-            zone_id = get_zone(account_id='8232ad8254d56191adf53b86920459fa', name=domain).zone_id
-
-        lb_dns_name = self.kwargs.get('load_balancer_dns_name',
-                                      self.container.load_balancer.load_balancer.dns_name)  # pragma: no cover
-
-        self.cname_record = Record(
-            'cname_record',
-            name=name,
-            type='CNAME',
-            zone_id=zone_id,
-            value=lb_dns_name,
-        )
-
-        pulumi.export("record_url", Output.concat("http://", self.cname_record.name, ".", domain))

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -122,10 +122,10 @@ class RailsComponent(pulumi.ComponentResource):
         domain = 'strongmind.com'
         zone_id = self.kwargs.get('zone_id')
         if not zone_id:  # pragma: no cover
-            zone_id = get_zone(account_id='8232ad8254d56191adf53b86920459fa', name=domain)
+            zone_id = get_zone(account_id='8232ad8254d56191adf53b86920459fa', name=domain).zone_id
 
         lb_dns_name = self.kwargs.get('load_balancer_dns_name',
-                                      self.container.fargate_service.service.load_balancers[0].dns_name)  # pragma: no cover
+                                      self.container.load_balancer.load_balancer.dns_name)  # pragma: no cover
 
         self.cname_record = Record(
             'cname_record',
@@ -134,3 +134,5 @@ class RailsComponent(pulumi.ComponentResource):
             zone_id=zone_id,
             value=lb_dns_name,
         )
+
+        pulumi.export("record_url", Output.concat("http://", self.cname_record.name, ".", domain))

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -119,6 +119,8 @@ class RailsComponent(pulumi.ComponentResource):
                              ':5432/app')
 
     def dns(self, name):
+        if self.env_name != "prod":
+            name = f"{self.env_name}-{name}"
         domain = 'strongmind.com'
         zone_id = self.kwargs.get('zone_id')
         if not zone_id:  # pragma: no cover

--- a/deployment/src/tests/test_rails.py
+++ b/deployment/src/tests/test_rails.py
@@ -314,33 +314,3 @@ def describe_a_pulumi_rails_app():
         assert sut.firewall_rule
         assert_outputs_equal(sut.firewall_rule.security_group_id, sut.rds_serverless_cluster.vpc_security_group_ids[0])
         assert_output_equals(sut.firewall_rule.source_security_group_id, ecs_security_group)
-
-    def describe_dns():
-        @pulumi.runtime.test
-        def it_has_cname_record(sut):
-            assert sut.cname_record
-
-        @pulumi.runtime.test
-        def it_has_name_with_environment_prefix(sut, environment, app_name):
-            return assert_output_equals(sut.cname_record.name, f"{environment}-{app_name}")
-
-        def describe_in_production():
-            @pytest.fixture
-            def environment():
-                return "prod"
-
-            @pulumi.runtime.test
-            def it_has_name_without_prefix(sut, app_name):
-                return assert_output_equals(sut.cname_record.name, app_name)
-
-        @pulumi.runtime.test
-        def it_has_cname_type(sut):
-            return assert_output_equals(sut.cname_record.type, "CNAME")
-
-        @pulumi.runtime.test
-        def it_has_zone(sut, zone_id):
-            return assert_output_equals(sut.cname_record.zone_id, zone_id)
-
-        @pulumi.runtime.test
-        def it_points_to_load_balancer(sut, load_balancer_dns_name):
-            return assert_output_equals(sut.cname_record.value, load_balancer_dns_name)

--- a/deployment/src/tests/test_rails.py
+++ b/deployment/src/tests/test_rails.py
@@ -319,3 +319,7 @@ def describe_a_pulumi_rails_app():
         @pulumi.runtime.test
         def it_has_zone(sut, zone_id):
             return assert_output_equals(sut.cname_record.zone_id, zone_id)
+
+        @pulumi.runtime.test
+        def it_points_to_load_balancer(sut, load_balancer_dns_name):
+            return assert_output_equals(sut.cname_record.value, load_balancer_dns_name)

--- a/deployment/src/tests/test_rails.py
+++ b/deployment/src/tests/test_rails.py
@@ -1,10 +1,8 @@
 import pulumi.runtime
 import pytest
-from pulumi_cloudflare import Record, Zone
 
 from tests.shared import assert_outputs_equal, assert_output_equals
 from tests.mocks import get_pulumi_mocks
-import pulumi_aws as aws
 
 
 def describe_a_pulumi_rails_app():
@@ -13,8 +11,12 @@ def describe_a_pulumi_rails_app():
         return faker.word()
 
     @pytest.fixture
-    def stack(faker):
-        return "dev"
+    def environment(faker):
+        return faker.word()
+
+    @pytest.fixture
+    def stack(faker, app_name, environment):
+        return f"{app_name}-{environment}"
 
     @pytest.fixture
     def master_db_password(faker):
@@ -89,10 +91,6 @@ def describe_a_pulumi_rails_app():
 
     @pytest.fixture
     def zone_id(faker):
-        return faker.word()
-
-    @pytest.fixture
-    def environment(faker):
         return faker.word()
 
     @pytest.fixture


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-899)

## Purpose 
Provide a friendly "name.strongmind.com" URL to apps out-of-the-box.

## Approach 
Use pulumi_cloudflare to create CNAME record pointing to the load balancer DNS name.

## Testing
Ran locally with frozen desserts. (http://stage-frozen-desserts.strongmind.com/)
