### PR TITLE
Block pushing new containers if they don't start up

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,6 +10,7 @@ on:
         default: ""
       test_docker_timeout:
         description: Number of seconds to wait for docker to start
+        required: false
         type: number
         default: 15
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Test docker
         run: |
           docker build -t test-docker .
-          CONTAINER_ID=$(docker run -e RAILS_ENV=test ${{ inputs.test_docker_run_extra_params }} -d test-docker)
+          CONTAINER_ID=$(docker run ${{ inputs.test_docker_run_extra_params }} -d test-docker)
           echo "Starting docker container $CONTAINER_ID and waiting for ${{ inputs.test_docker_timeout }} seconds"
           sleep ${{ inputs.test_docker_timeout }}
           OUTPUT=$(docker logs $CONTAINER_ID --tail 20)

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,6 +2,16 @@ name: Build docker and Upload to ECR
 
 on:
   workflow_call:
+    inputs:
+      test_docker_run_extra_params:
+        description: List of extra params to pass to docker run (for things like environment variables that are required to start)
+        required: false
+        type: string
+        default: ""
+      test_docker_timeout:
+        description: Number of seconds to wait for docker to start
+        type: number
+        default: 15
 
 env:
   AWS_REGION: us-west-2
@@ -10,8 +20,28 @@ permissions:
   contents: read
 
 jobs:
+  test-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Test docker
+        run: |
+          docker build -t test-docker .
+          CONTAINER_ID=$(docker run -e RAILS_ENV=test ${{ inputs.test_docker_run_extra_params }} -d test-docker)
+          echo "Starting docker container $CONTAINER_ID and waiting for ${{ inputs.test_docker_timeout }} seconds"
+          sleep ${{ inputs.test_docker_timeout }}
+          OUTPUT=$(docker logs $CONTAINER_ID --tail 20)
+
+          if [[ $OUTPUT != *"Listening on http://0.0.0.0:3000"* ]]; then
+            echo "Dockerfile test failed"
+            echo $OUTPUT
+            exit 1
+          fi
   build-image:
     name: Build image
+    needs: test-docker
     runs-on: ubuntu-latest
     environment: containers
 


### PR DESCRIPTION
## Purpose 
We've hit an issue a lot where it appears that a build is deployed but then ECS fails when it attempts to spin up the container.

## Approach 
Build and run container locally to make sure it starts up before pushing it to ECR.

## Testing
Tried this out in https://github.com/StrongMind/course-builder/blob/main/.github/workflows/build.yml
