### PR TITLE
Use /up for health check

### DIFF
--- a/deployment/pyproject.toml
+++ b/deployment/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "strongmind_deployment"
-version = "1.0.1"
+version = "1.0.2"
 authors = [
   { name="Belding", email="teambelding@strongmind.com" },
 ]

--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -52,10 +52,10 @@ class ContainerComponent(pulumi.ComponentResource):
             target_type="ip",
             health_check=aws.lb.TargetGroupHealthCheckArgs(
                 enabled=True,
-                path="/",
+                path="/up",
                 port=str(self.container_port),
                 protocol="HTTP",
-                matcher="200-399",
+                matcher="200",
                 interval=30,
                 timeout=5,
                 healthy_threshold=5,

--- a/deployment/src/tests/test_container.py
+++ b/deployment/src/tests/test_container.py
@@ -184,12 +184,12 @@ def describe_a_pulumi_containerized_app():
                     return assert_output_equals(sut.target_group.health_check.interval, 30)
 
                 @pulumi.runtime.test
-                def it_sets_the_default_target_group_health_check_matcher(sut):
-                    return assert_output_equals(sut.target_group.health_check.matcher, "200-399")
+                def it_sets_the_default_target_group_health_check_matcher_to_200(sut):
+                    return assert_output_equals(sut.target_group.health_check.matcher, "200")
 
                 @pulumi.runtime.test
-                def it_sets_the_default_target_group_health_check_path(sut):
-                    return assert_output_equals(sut.target_group.health_check.path, "/")
+                def it_sets_the_default_target_group_health_check_path_to_up(sut):
+                    return assert_output_equals(sut.target_group.health_check.path, "/up")
 
                 @pulumi.runtime.test
                 def it_sets_the_default_target_group_health_check_protocol(sut):

--- a/deployment/src/tests/test_container.py
+++ b/deployment/src/tests/test_container.py
@@ -162,6 +162,43 @@ def describe_a_pulumi_containerized_app():
             def it_sets_the_load_balancer_name(sut, stack, app_name):
                 return assert_output_equals(sut.load_balancer.name, f"{app_name}-{stack}")
 
+            def describe_target_group():
+                @pulumi.runtime.test
+                def it_sets_the_default_target_group_port(sut, container_port):
+                    return assert_output_equals(sut.target_group.port, container_port)
+
+                @pulumi.runtime.test
+                def it_sets_the_default_target_group_health_check_enabled(sut):
+                    return assert_output_equals(sut.target_group.health_check.enabled, True)
+
+                @pulumi.runtime.test
+                def it_sets_the_default_target_group_health_check_healthy_threshold(sut):
+                    return assert_output_equals(sut.target_group.health_check.healthy_threshold, 5)
+
+                @pulumi.runtime.test
+                def it_sets_the_default_target_group_health_check_unhealthy_threshold(sut):
+                    return assert_output_equals(sut.target_group.health_check.unhealthy_threshold, 2)
+
+                @pulumi.runtime.test
+                def it_sets_the_default_target_group_health_check_interval(sut):
+                    return assert_output_equals(sut.target_group.health_check.interval, 30)
+
+                @pulumi.runtime.test
+                def it_sets_the_default_target_group_health_check_matcher(sut):
+                    return assert_output_equals(sut.target_group.health_check.matcher, "200-399")
+
+                @pulumi.runtime.test
+                def it_sets_the_default_target_group_health_check_path(sut):
+                    return assert_output_equals(sut.target_group.health_check.path, "/")
+
+                @pulumi.runtime.test
+                def it_sets_the_default_target_group_health_check_protocol(sut):
+                    return assert_output_equals(sut.target_group.health_check.protocol, "HTTP")
+
+                @pulumi.runtime.test
+                def it_sets_the_default_target_group_health_check_timeout(sut):
+                    return assert_output_equals(sut.target_group.health_check.timeout, 5)
+
             def describe_the_load_balancer_listener_for_https():
                 @pytest.fixture
                 def listener(sut):
@@ -179,19 +216,15 @@ def describe_a_pulumi_containerized_app():
                 def it_sets_the_certificate_arn(listener, sut):
                     return assert_outputs_equal(listener.certificate_arn, sut.cert.arn)
 
-                @pulumi.runtime.test
                 def it_sets_the_port(listener):
                     return assert_output_equals(listener.port, 443)
 
-                @pulumi.runtime.test
                 def it_sets_the_protocol(listener):
                     return assert_output_equals(listener.protocol, "HTTPS")
 
-                @pulumi.runtime.test
                 def it_forwards_to_the_target_group(listener, target_group_arn):
                     return assert_output_equals(listener.default_actions[0].target_group_arn, target_group_arn)
 
-                @pulumi.runtime.test
                 def it_forwards(listener):
                     return assert_output_equals(listener.default_actions[0].type, "forward")
 
@@ -208,27 +241,21 @@ def describe_a_pulumi_containerized_app():
                 def it_sets_the_load_balancer_arn(listener, load_balancer_arn):
                     return assert_output_equals(listener.load_balancer_arn, load_balancer_arn)
 
-                @pulumi.runtime.test
                 def it_sets_the_port(listener):
                     return assert_output_equals(listener.port, 80)
 
-                @pulumi.runtime.test
                 def it_sets_the_protocol(listener):
                     return assert_output_equals(listener.protocol, "HTTP")
 
-                @pulumi.runtime.test
                 def it_redirects_to_443(listener):
                     return assert_output_equals(listener.default_actions[0].redirect.port, "443")
 
-                @pulumi.runtime.test
                 def it_redirects_to_https(listener):
                     return assert_output_equals(listener.default_actions[0].redirect.protocol, "HTTPS")
 
-                @pulumi.runtime.test
                 def it_redirects_with_301(listener):
                     return assert_output_equals(listener.default_actions[0].redirect.status_code, "HTTP_301")
 
-                @pulumi.runtime.test
                 def it_redirects(listener):
                     return assert_output_equals(listener.default_actions[0].type, "redirect")
 


### PR DESCRIPTION
## Purpose 
Noticed this when looking at course-builder deployment. If we redirect on the root / the health check fails and the image is never updated.

## Approach 
Use /up for the health check.

## Testing
Unit tests.