### PR TITLE
BEL-934 Add redis queue/cache components

### DIFF
--- a/deployment/requirements.txt
+++ b/deployment/requirements.txt
@@ -6,5 +6,7 @@ pulumi-random
 
 pytest-describe
 faker
+mockito
+pytest-mockito
 
 wheel

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -51,8 +51,11 @@ class RailsComponent(pulumi.ComponentResource):
         if 'cache_redis' in self.kwargs:
             if isinstance(self.kwargs['cache_redis'], RedisComponent):
                 self.cache_redis = self.kwargs['cache_redis']
-            else:
+            elif self.kwargs['cache_redis']:
                 self.cache_redis = CacheComponent("cache-redis")
+
+            if self.cache_redis:
+                self.env_vars['CACHE_REDIS_URL'] = self.cache_redis.url
 
         self.ecs()
 

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -38,9 +38,17 @@ class RailsComponent(pulumi.ComponentResource):
         }
 
         self.rds(project_stack)
+        redis_kwargs = {}
+        if 'redis_node_type' in self.kwargs:
+            redis_kwargs['node_type'] = self.kwargs['redis_node_type']
+
+        if 'redis_num_cache_nodes' in self.kwargs:
+            redis_kwargs['num_cache_nodes'] = self.kwargs['redis_num_cache_nodes']
 
         self.redis = RedisComponent("redis",
-                                    env_vars=self.env_vars)
+                                    env_vars=self.env_vars,
+                                    **redis_kwargs
+                                    )
         export("redis_endpoint", Output.concat(self.redis.cluster.cache_nodes[0]['address']))
 
         self.ecs()

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -29,9 +29,9 @@ class RailsComponent(pulumi.ComponentResource):
                                                               "rails server --port 3000 -b 0.0.0.0"]`
     :param need_worker: Whether or not to create a worker container. Defaults to True if sidekiq is in the Gemfile.
     :param worker_entry_point: The entry point for the worker container. Defaults to `["sh", "-c", "bundle exec sidekiq"]`
-    :param cpu: The number of CPU units to reserve for the container. Defaults to 256.
-    :param memory: The amount of memory (in MiB) to allow the container to use. Defaults to 512.
-    :param app_path: The path to the Rails application. Defaults to `./`.
+    :param cpu: The number of CPU units to reserve for the web container. Defaults to 256.
+    :param memory: The amount of memory (in MiB) to allow the web container to use. Defaults to 512.
+    :param app_path: The path to the Rails application for the web. Defaults to `./`.
     :param worker_cpu: The number of CPU units to reserve for the worker container. Defaults to 256.
     :param worker_memory: The amount of memory (in MiB) to allow the worker container to use. Defaults to 512.
     :param worker_app_path: The path to the Rails application for the worker. Defaults to `./`.

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -46,7 +46,7 @@ class RailsComponent(pulumi.ComponentResource):
                 self.queue_redis = QueueComponent("queue-redis")
 
             if self.queue_redis:
-                self.env_vars['QUEUE_REDIS_URL'] = self.queue_redis.get_url()
+                self.env_vars['QUEUE_REDIS_URL'] = self.queue_redis.url
 
         if 'cache_redis' in self.kwargs:
             if isinstance(self.kwargs['cache_redis'], RedisComponent):

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -20,19 +20,21 @@ class RailsComponent(pulumi.ComponentResource):
 
     :param name: The _unique_ name of the resource.
     :param opts: A bag of optional settings that control this resource's behavior.
-    :param kwargs:
-        - env_vars: A dictionary of environment variables to pass to the Rails application.
-        - queue_redis: Either True to create a default queue Redis instance or a RedisComponent to use. Defaults to True if sidekiq is in the Gemfile.
-        - cache_redis: Either True to create a default cache Redis instance or a RedisComponent to use.
-        - web_entry_point: The entry point for the web container. Defaults to `["sh", "-c",
+    :param env_vars: A dictionary of environment variables to pass to the Rails application.
+    :param queue_redis: Either True to create a default queue Redis instance or a RedisComponent to use. Defaults to True if sidekiq is in the Gemfile.
+    :param cache_redis: Either True to create a default cache Redis instance or a RedisComponent to use.
+    :param web_entry_point: The entry point for the web container. Defaults to `["sh", "-c",
                                                               "rails db:prepare db:migrate db:seed && "
                                                               "rails assets:precompile && "
                                                               "rails server --port 3000 -b 0.0.0.0"]`
-        - need_worker: Whether or not to create a worker container. Defaults to True if sidekiq is in the Gemfile.
-        - worker_entry_point: The entry point for the worker container. Defaults to `["sh", "-c", "bundle exec sidekiq"]`
-
-
-
+    :param need_worker: Whether or not to create a worker container. Defaults to True if sidekiq is in the Gemfile.
+    :param worker_entry_point: The entry point for the worker container. Defaults to `["sh", "-c", "bundle exec sidekiq"]`
+    :param cpu: The number of CPU units to reserve for the container. Defaults to 256.
+    :param memory: The amount of memory (in MiB) to allow the container to use. Defaults to 512.
+    :param app_path: The path to the Rails application. Defaults to `./`.
+    :param worker_cpu: The number of CPU units to reserve for the worker container. Defaults to 256.
+    :param worker_memory: The amount of memory (in MiB) to allow the worker container to use. Defaults to 512.
+    :param worker_app_path: The path to the Rails application for the worker. Defaults to `./`.
     """
     def __init__(self, name, opts=None, **kwargs):
         super().__init__('strongmind:global_build:commons:rails', name, None, opts)

--- a/deployment/src/strongmind_deployment/redis.py
+++ b/deployment/src/strongmind_deployment/redis.py
@@ -9,6 +9,8 @@ class RedisComponent(pulumi.ComponentResource):
         super().__init__('strongmind:global_build:commons:redis', name, None, opts)
         self.kwargs = kwargs
         self.env_vars = self.kwargs.get('env_vars', {})
+        self.node_type = self.kwargs.get('node_type', 'cache.t4g.small')
+        self.num_cache_nodes = self.kwargs.get('num_cache_nodes', 1)
 
         self.env_name = os.environ.get('ENVIRONMENT_NAME', 'stage')
 
@@ -27,9 +29,9 @@ class RedisComponent(pulumi.ComponentResource):
             "redis",
             cluster_id=project_stack,
             engine="redis",
-            node_type="cache.t4g.small",
+            node_type=self.node_type,
             engine_version="7.0",
-            num_cache_nodes=1,
+            num_cache_nodes=self.num_cache_nodes,
             parameter_group_name="default.redis7",
             port=6379,
             tags=self.tags,

--- a/deployment/src/strongmind_deployment/redis.py
+++ b/deployment/src/strongmind_deployment/redis.py
@@ -2,6 +2,7 @@ import os
 
 import pulumi
 import pulumi_aws as aws
+from pulumi import Output
 
 
 class RedisComponent(pulumi.ComponentResource):
@@ -17,7 +18,6 @@ class RedisComponent(pulumi.ComponentResource):
 
         project = pulumi.get_project()
         stack = pulumi.get_stack()
-        project_stack = f"{project}-{stack}"
 
         self.tags = {
             "product": project,
@@ -28,7 +28,7 @@ class RedisComponent(pulumi.ComponentResource):
 
         self.cluster = aws.elasticache.Cluster(
             "redis",
-            cluster_id=project_stack,
+            cluster_id=f'{stack}-{name}',
             engine="redis",
             node_type=self.node_type,
             engine_version="7.0",
@@ -40,6 +40,9 @@ class RedisComponent(pulumi.ComponentResource):
         )
 
         self.register_outputs({})
+
+    def get_url(self):
+        return Output.concat("redis://", self.cluster.cache_nodes[0].address, ":6379")
 
 
 class QueueComponent(RedisComponent):

--- a/deployment/src/strongmind_deployment/redis.py
+++ b/deployment/src/strongmind_deployment/redis.py
@@ -41,7 +41,8 @@ class RedisComponent(pulumi.ComponentResource):
 
         self.register_outputs({})
 
-    def get_url(self):
+    @property
+    def url(self):
         return Output.concat("redis://", self.cluster.cache_nodes[0].address, ":6379")
 
 

--- a/deployment/src/strongmind_deployment/redis.py
+++ b/deployment/src/strongmind_deployment/redis.py
@@ -13,6 +13,7 @@ class RedisComponent(pulumi.ComponentResource):
         self.num_cache_nodes = self.kwargs.get('num_cache_nodes', 1)
 
         self.env_name = os.environ.get('ENVIRONMENT_NAME', 'stage')
+        self.parameter_group_name = self.kwargs.get('parameter_group_name', 'default.redis7')
 
         project = pulumi.get_project()
         stack = pulumi.get_stack()
@@ -32,10 +33,30 @@ class RedisComponent(pulumi.ComponentResource):
             node_type=self.node_type,
             engine_version="7.0",
             num_cache_nodes=self.num_cache_nodes,
-            parameter_group_name="default.redis7",
+            parameter_group_name=self.parameter_group_name,
             port=6379,
             tags=self.tags,
             opts=pulumi.ResourceOptions(parent=self),
         )
 
         self.register_outputs({})
+
+
+class QueueComponent(RedisComponent):
+    def __init__(self, name, opts=None, **kwargs):
+        kwargs['parameter_group_name'] = f'{name}.queue.redis7'
+        self.parameter_group = aws.elasticache.ParameterGroup(
+            kwargs['parameter_group_name'],
+            family="redis7",
+        )
+        super().__init__(name, opts, **kwargs)
+
+
+class CacheComponent(RedisComponent):
+    def __init__(self, name, opts=None, **kwargs):
+        kwargs['parameter_group_name'] = f'{name}.cache.redis7'
+        self.parameter_group = aws.elasticache.ParameterGroup(
+            kwargs['parameter_group_name'],
+            family="redis7",
+        )
+        super().__init__(name, opts, **kwargs)

--- a/deployment/src/strongmind_deployment/redis.py
+++ b/deployment/src/strongmind_deployment/redis.py
@@ -27,7 +27,7 @@ class RedisComponent(pulumi.ComponentResource):
         }
 
         self.cluster = aws.elasticache.Cluster(
-            "redis",
+            name,
             cluster_id=f'{stack}-{name}',
             engine="redis",
             node_type=self.node_type,

--- a/deployment/src/strongmind_deployment/redis.py
+++ b/deployment/src/strongmind_deployment/redis.py
@@ -48,7 +48,7 @@ class RedisComponent(pulumi.ComponentResource):
 
 class QueueComponent(RedisComponent):
     def __init__(self, name, opts=None, **kwargs):
-        kwargs['parameter_group_name'] = f'{name}.queue.redis7'
+        kwargs['parameter_group_name'] = f'{name}-queue-redis7'
         self.parameter_group = aws.elasticache.ParameterGroup(
             kwargs['parameter_group_name'],
             family="redis7",
@@ -63,7 +63,7 @@ class QueueComponent(RedisComponent):
 
 class CacheComponent(RedisComponent):
     def __init__(self, name, opts=None, **kwargs):
-        kwargs['parameter_group_name'] = f'{name}.cache.redis7'
+        kwargs['parameter_group_name'] = f'{name}-cache-redis7'
         self.parameter_group = aws.elasticache.ParameterGroup(
             kwargs['parameter_group_name'],
             family="redis7",

--- a/deployment/src/strongmind_deployment/redis.py
+++ b/deployment/src/strongmind_deployment/redis.py
@@ -48,6 +48,11 @@ class QueueComponent(RedisComponent):
         self.parameter_group = aws.elasticache.ParameterGroup(
             kwargs['parameter_group_name'],
             family="redis7",
+            parameters=[
+                aws.elasticache.ParameterGroupParameterArgs(
+                    name="maxmemory-policy",
+                    value="noeviction")
+            ]
         )
         super().__init__(name, opts, **kwargs)
 

--- a/deployment/src/tests/mocks.py
+++ b/deployment/src/tests/mocks.py
@@ -64,6 +64,11 @@ def get_pulumi_mocks(faker, fake_password=None):
                         }
                     ],
                 }
+            if args.typ == "aws:elasticache/parameterGroup:ParameterGroup":
+                outputs = {
+                    **args.inputs,
+                    "name": args.name,
+                }
             return [args.name + '_id', outputs]
 
         def call(self, args: pulumi.runtime.MockCallArgs):

--- a/deployment/src/tests/mocks.py
+++ b/deployment/src/tests/mocks.py
@@ -66,8 +66,7 @@ def get_pulumi_mocks(faker, fake_password=None):
                 }
             if args.typ == "aws:elasticache/parameterGroup:ParameterGroup":
                 outputs = {
-                    **args.inputs,
-                    "name": args.name,
+                    **args.inputs
                 }
             if args.typ == "aws:elasticache/parameterGroup:ParameterGroupParameterArgs":
                 outputs = {

--- a/deployment/src/tests/mocks.py
+++ b/deployment/src/tests/mocks.py
@@ -69,6 +69,10 @@ def get_pulumi_mocks(faker, fake_password=None):
                     **args.inputs,
                     "name": args.name,
                 }
+            if args.typ == "aws:elasticache/parameterGroup:ParameterGroupParameterArgs":
+                outputs = {
+                    **args.inputs
+                }
             return [args.name + '_id', outputs]
 
         def call(self, args: pulumi.runtime.MockCallArgs):

--- a/deployment/src/tests/test_rails.py
+++ b/deployment/src/tests/test_rails.py
@@ -432,7 +432,7 @@ def describe_a_pulumi_rails_app():
 
         @pulumi.runtime.test
         def it_sends_the_url_to_the_ecs_environment(sut):
-            return assert_outputs_equal(sut.env_vars["QUEUE_REDIS_URL"], sut.queue_redis.get_url())
+            return assert_outputs_equal(sut.env_vars["QUEUE_REDIS_URL"], sut.queue_redis.url)
 
     def describe_with_custom_queue_redis():
         @pytest.fixture

--- a/deployment/src/tests/test_rails.py
+++ b/deployment/src/tests/test_rails.py
@@ -427,8 +427,8 @@ def describe_a_pulumi_rails_app():
             assert isinstance(sut.queue_redis, QueueComponent)
 
         @pulumi.runtime.test
-        def test_it_names_the_queue_redis_with_the_stack_name(sut, stack):
-            return assert_output_equals(sut.queue_redis.cluster.cluster_id, f"{stack}-queue-redis")
+        def test_it_names_the_queue_redis(sut, app_name, stack):
+            return assert_output_equals(sut.queue_redis.cluster.cluster_id, f"{app_name}-{stack}-queue-redis")
 
         @pulumi.runtime.test
         def it_sends_the_url_to_the_ecs_environment(sut):
@@ -446,8 +446,8 @@ def describe_a_pulumi_rails_app():
             assert isinstance(sut.queue_redis, QueueComponent)
 
         @pulumi.runtime.test
-        def test_it_names_the_queue_redis_with_the_stack_name(sut, stack):
-            return assert_output_equals(sut.queue_redis.cluster.cluster_id, f"{stack}-custom-queue-redis")
+        def test_it_names_the_queue_redis(sut, app_name, stack):
+            return assert_output_equals(sut.queue_redis.cluster.cluster_id, f"{app_name}-{stack}-custom-queue-redis")
 
     def describe_with_cache_redis_enabled():
         @pytest.fixture
@@ -461,8 +461,8 @@ def describe_a_pulumi_rails_app():
             assert isinstance(sut.cache_redis, CacheComponent)
 
         @pulumi.runtime.test
-        def it_names_the_cache_redis_with_the_stack_name(sut, stack):
-            return assert_output_equals(sut.cache_redis.cluster.cluster_id, f"{stack}-cache-redis")
+        def it_names_the_cache_redis(sut, app_name, stack):
+            return assert_output_equals(sut.cache_redis.cluster.cluster_id, f"{app_name}-{stack}-cache-redis")
 
         @pulumi.runtime.test
         def it_sends_the_url_to_the_ecs_environment(sut):
@@ -480,5 +480,5 @@ def describe_a_pulumi_rails_app():
             assert isinstance(sut.cache_redis, CacheComponent)
 
         @pulumi.runtime.test
-        def it_names_the_cache_redis_with_the_stack_name(sut, stack):
-            return assert_output_equals(sut.cache_redis.cluster.cluster_id, f"{stack}-custom-cache-redis")
+        def it_names_the_cache_redis(sut, app_name, stack):
+            return assert_output_equals(sut.cache_redis.cluster.cluster_id, f"{app_name}-{stack}-custom-cache-redis")

--- a/deployment/src/tests/test_rails.py
+++ b/deployment/src/tests/test_rails.py
@@ -464,6 +464,10 @@ def describe_a_pulumi_rails_app():
         def it_names_the_cache_redis_with_the_stack_name(sut, stack):
             return assert_output_equals(sut.cache_redis.cluster.cluster_id, f"{stack}-cache-redis")
 
+        @pulumi.runtime.test
+        def it_sends_the_url_to_the_ecs_environment(sut):
+            return assert_outputs_equal(sut.env_vars["CACHE_REDIS_URL"], sut.cache_redis.url)
+
     def describe_with_custom_cache_redis():
         @pytest.fixture
         def component_kwargs(component_kwargs):

--- a/deployment/src/tests/test_rails.py
+++ b/deployment/src/tests/test_rails.py
@@ -1,4 +1,5 @@
 import os
+from io import StringIO
 
 import pulumi.runtime
 import pytest
@@ -414,6 +415,30 @@ def describe_a_pulumi_rails_app():
     def it_does_not_create_a_cache_redis(sut):
         # to save money, we don't create a cache redis if it is not requested
         assert not hasattr(sut, 'cache_redis')
+
+    def describe_with_sidekiq_present():
+        @pytest.fixture
+        def gemfile_exists(when):
+            # Using mockito, mock the os.path.exists function to return True if the path is ../Gemfile
+            when(os.path).exists('../Gemfile').thenReturn(True)
+
+        @pytest.fixture
+        def gemfile(when):
+            # Mock the open function to return a StringIO object with the contents of the Gemfile
+            # when(open)('../Gemfile').thenReturn(StringIO('gem "sidekiq"'))
+            pass
+
+        @pytest.fixture
+        def sut(gemfile_exists, sut):
+            return sut
+
+        @pulumi.runtime.test
+        def it_creates_a_queue_redis(sut, gemfile_exists, gemfile):
+            assert hasattr(sut, 'queue_redis')
+
+        @pulumi.runtime.test
+        def it_configures_redis_provider():
+            pass
 
     def describe_with_queue_redis_enabled():
         @pytest.fixture

--- a/deployment/src/tests/test_redis.py
+++ b/deployment/src/tests/test_redis.py
@@ -119,12 +119,12 @@ def describe_a_pulumi_redis_component():
 
         @pulumi.runtime.test
         def it_uses_a_queue_parameter_group(sut, stack):
-            return assert_output_equals(sut.cluster.parameter_group_name, f"{stack}.queue.redis7")
+            return assert_output_equals(sut.cluster.parameter_group_name, f"{stack}-queue-redis7")
 
         @pulumi.runtime.test
         def it_creates_its_parameter_group(sut, stack):
             assert isinstance(sut.parameter_group, pulumi_aws.elasticache.ParameterGroup)
-            return assert_output_equals(sut.parameter_group.name, f"{stack}.queue.redis7")
+            return assert_output_equals(sut.parameter_group.name, f"{stack}-queue-redis7")
 
         @pulumi.runtime.test
         def it_sets_the_parameter_group_family(sut):
@@ -147,12 +147,12 @@ def describe_a_pulumi_redis_component():
 
         @pulumi.runtime.test
         def it_uses_a_cache_parameter_group(sut, stack):
-            return assert_output_equals(sut.cluster.parameter_group_name, f"{stack}.cache.redis7")
+            return assert_output_equals(sut.cluster.parameter_group_name, f"{stack}-cache-redis7")
 
         @pulumi.runtime.test
         def it_creates_its_parameter_group(sut, stack):
             assert isinstance(sut.parameter_group, pulumi_aws.elasticache.ParameterGroup)
-            return assert_output_equals(sut.parameter_group.name, f"{stack}.cache.redis7")
+            return assert_output_equals(sut.parameter_group.name, f"{stack}-cache-redis7")
 
         @pulumi.runtime.test
         def it_sets_the_parameter_group_family(sut):

--- a/deployment/src/tests/test_redis.py
+++ b/deployment/src/tests/test_redis.py
@@ -1,6 +1,7 @@
 import os
 
 import pulumi.runtime
+import pulumi_aws
 import pytest
 
 from tests.shared import assert_outputs_equal, assert_output_equals
@@ -71,7 +72,6 @@ def describe_a_pulumi_redis_component():
             def it_has_num_cache_nodes(sut):
                 return assert_output_equals(sut.cluster.num_cache_nodes, 1)
 
-
         def describe_with_scaling_overrides():
             @pytest.fixture
             def component_arguments():
@@ -90,13 +90,46 @@ def describe_a_pulumi_redis_component():
 
     def describe_a_redis_queue_cluster():
         @pytest.fixture
-        def sut(component_arguments):
+        def sut(component_arguments, stack):
             import strongmind_deployment.redis
 
-            sut = strongmind_deployment.redis.QueueComponent("queue_redis",
+            sut = strongmind_deployment.redis.QueueComponent(stack,
                                                              **component_arguments
                                                              )
             return sut
 
-        def it_has_a_parameter_group(sut):
-            assert sut.parameter_group
+        @pulumi.runtime.test
+        def it_uses_a_queue_parameter_group(sut, stack):
+            return assert_output_equals(sut.cluster.parameter_group_name, f"{stack}.queue.redis7")
+
+        @pulumi.runtime.test
+        def it_creates_its_parameter_group(sut, stack):
+            assert isinstance(sut.parameter_group, pulumi_aws.elasticache.ParameterGroup)
+            return assert_output_equals(sut.parameter_group.name, f"{stack}.queue.redis7")
+
+        @pulumi.runtime.test
+        def it_sets_the_parameter_group_family(sut):
+            return assert_output_equals(sut.parameter_group.family, "redis7")
+
+    def describe_a_redis_cache_cluster():
+        @pytest.fixture
+        def sut(component_arguments, stack):
+            import strongmind_deployment.redis
+
+            sut = strongmind_deployment.redis.CacheComponent(stack,
+                                                             **component_arguments
+                                                             )
+            return sut
+
+        @pulumi.runtime.test
+        def it_uses_a_cache_parameter_group(sut, stack):
+            return assert_output_equals(sut.cluster.parameter_group_name, f"{stack}.cache.redis7")
+
+        @pulumi.runtime.test
+        def it_creates_its_parameter_group(sut, stack):
+            assert isinstance(sut.parameter_group, pulumi_aws.elasticache.ParameterGroup)
+            return assert_output_equals(sut.parameter_group.name, f"{stack}.cache.redis7")
+
+        @pulumi.runtime.test
+        def it_sets_the_parameter_group_family(sut):
+            return assert_output_equals(sut.parameter_group.family, "redis7")

--- a/deployment/src/tests/test_redis.py
+++ b/deployment/src/tests/test_redis.py
@@ -20,7 +20,7 @@ def describe_a_pulumi_redis_component():
 
     @pytest.fixture
     def stack(faker, app_name, environment):
-        return f"{app_name}-{environment}"
+        return f"{environment}"
 
     @pytest.fixture
     def pulumi_mocks(faker):
@@ -56,8 +56,8 @@ def describe_a_pulumi_redis_component():
             assert sut.cluster._name == name
 
         @pulumi.runtime.test
-        def it_has_a_cluster_id(sut, name, stack):
-            return assert_output_equals(sut.cluster.cluster_id, f"{stack}-{name}")
+        def test_it_has_a_cluster_id(sut, name, app_name, stack):
+            return assert_output_equals(sut.cluster.cluster_id, f"{app_name}-{stack}-{name}")
 
         @pulumi.runtime.test
         def it_has_engine_redis(sut):
@@ -118,13 +118,13 @@ def describe_a_pulumi_redis_component():
             return sut
 
         @pulumi.runtime.test
-        def it_uses_a_queue_parameter_group(sut, stack):
-            return assert_output_equals(sut.cluster.parameter_group_name, f"{stack}-queue-redis7")
+        def it_uses_a_queue_parameter_group(sut, app_name, stack):
+            return assert_output_equals(sut.cluster.parameter_group_name, f"{app_name}-{stack}-queue-redis7")
 
         @pulumi.runtime.test
-        def it_creates_its_parameter_group(sut, stack):
+        def it_creates_its_parameter_group(sut, app_name, stack):
             assert isinstance(sut.parameter_group, pulumi_aws.elasticache.ParameterGroup)
-            return assert_output_equals(sut.parameter_group.name, f"{stack}-queue-redis7")
+            return assert_output_equals(sut.parameter_group.name, f"{app_name}-{stack}-queue-redis7")
 
         @pulumi.runtime.test
         def it_sets_the_parameter_group_family(sut):
@@ -146,13 +146,13 @@ def describe_a_pulumi_redis_component():
             return sut
 
         @pulumi.runtime.test
-        def it_uses_a_cache_parameter_group(sut, stack):
-            return assert_output_equals(sut.cluster.parameter_group_name, f"{stack}-cache-redis7")
+        def it_uses_a_cache_parameter_group(sut, app_name, stack):
+            return assert_output_equals(sut.cluster.parameter_group_name, f"{app_name}-{stack}-cache-redis7")
 
         @pulumi.runtime.test
-        def it_creates_its_parameter_group(sut, stack):
+        def it_creates_its_parameter_group(sut, app_name, stack):
             assert isinstance(sut.parameter_group, pulumi_aws.elasticache.ParameterGroup)
-            return assert_output_equals(sut.parameter_group.name, f"{stack}-cache-redis7")
+            return assert_output_equals(sut.parameter_group.name, f"{app_name}-{stack}-cache-redis7")
 
         @pulumi.runtime.test
         def it_sets_the_parameter_group_family(sut):

--- a/deployment/src/tests/test_redis.py
+++ b/deployment/src/tests/test_redis.py
@@ -111,6 +111,12 @@ def describe_a_pulumi_redis_component():
         def it_sets_the_parameter_group_family(sut):
             return assert_output_equals(sut.parameter_group.family, "redis7")
 
+        @pulumi.runtime.test
+        def it_sets_the_cache_eviction_policy_to_noeviction(sut):
+            assert_output_equals(sut.parameter_group.parameters[0].name, "maxmemory-policy")
+            assert_output_equals(sut.parameter_group.parameters[0].value, "noeviction")
+
+
     def describe_a_redis_cache_cluster():
         @pytest.fixture
         def sut(component_arguments, stack):
@@ -133,3 +139,8 @@ def describe_a_pulumi_redis_component():
         @pulumi.runtime.test
         def it_sets_the_parameter_group_family(sut):
             return assert_output_equals(sut.parameter_group.family, "redis7")
+
+        @pulumi.runtime.test
+        def it_sets_the_cache_eviction_policy_to_volatile_lru(sut):
+            assert_output_equals(sut.parameter_group.parameters[0].name, "maxmemory-policy")
+            assert_output_equals(sut.parameter_group.parameters[0].value, "volatile-lru")

--- a/deployment/src/tests/test_redis.py
+++ b/deployment/src/tests/test_redis.py
@@ -66,7 +66,7 @@ def describe_a_pulumi_redis_component():
 
         @pulumi.runtime.test
         def it_has_url(sut):
-            return assert_outputs_equal(sut.get_url(),
+            return assert_outputs_equal(sut.url,
                                         Output.concat('redis://',
                                                       sut.cluster.cache_nodes[0].address,
                                                       ':6379'))

--- a/deployment/src/tests/test_redis.py
+++ b/deployment/src/tests/test_redis.py
@@ -25,11 +25,17 @@ def describe_a_pulumi_redis_component():
         return get_pulumi_mocks(faker)
 
     @pytest.fixture
+    def component_arguments():
+        return {}
+
+    @pytest.fixture
     def sut(pulumi_set_mocks,
+            component_arguments
             ):
         import strongmind_deployment.redis
 
         sut = strongmind_deployment.redis.RedisComponent("redis",
+                                                         **component_arguments
                                                          )
         return sut
 
@@ -49,17 +55,35 @@ def describe_a_pulumi_redis_component():
             return assert_output_equals(sut.cluster.engine_version, "7.0")
 
         @pulumi.runtime.test
-        def test_it_has_node_type(sut):
-            return assert_output_equals(sut.cluster.node_type, "cache.t4g.small")
-
-        @pulumi.runtime.test
-        def it_has_num_cache_nodes(sut):
-            return assert_output_equals(sut.cluster.num_cache_nodes, 1)
-
-        @pulumi.runtime.test
         def it_has_parameter_group_name(sut):
             return assert_output_equals(sut.cluster.parameter_group_name, "default.redis7")
 
         @pulumi.runtime.test
         def it_has_port(sut):
             return assert_output_equals(sut.cluster.port, 6379)
+
+        def describe_with_defaults():
+            @pulumi.runtime.test
+            def test_it_has_node_type(sut):
+                return assert_output_equals(sut.cluster.node_type, "cache.t4g.small")
+
+            @pulumi.runtime.test
+            def it_has_num_cache_nodes(sut):
+                return assert_output_equals(sut.cluster.num_cache_nodes, 1)
+
+
+        def describe_with_scaling_overrides():
+            @pytest.fixture
+            def component_arguments():
+                return {
+                    "node_type": "cache.t3.small",
+                    "num_cache_nodes": 2,
+                }
+
+            @pulumi.runtime.test
+            def it_has_node_type(sut, component_arguments):
+                return assert_output_equals(sut.cluster.node_type, "cache.t3.small")
+
+            @pulumi.runtime.test
+            def it_has_num_cache_nodes(sut, component_arguments):
+                return assert_output_equals(sut.cluster.num_cache_nodes, 2)

--- a/deployment/src/tests/test_redis.py
+++ b/deployment/src/tests/test_redis.py
@@ -27,16 +27,20 @@ def describe_a_pulumi_redis_component():
         return get_pulumi_mocks(faker)
 
     @pytest.fixture
+    def name(faker):
+        return faker.word()
+
+    @pytest.fixture
     def component_arguments():
         return {}
 
     @pytest.fixture
     def sut(pulumi_set_mocks,
-            component_arguments
-            ):
+            component_arguments,
+            name):
         import strongmind_deployment.redis
 
-        sut = strongmind_deployment.redis.RedisComponent("redis",
+        sut = strongmind_deployment.redis.RedisComponent(name,
                                                          **component_arguments
                                                          )
         return sut
@@ -47,6 +51,13 @@ def describe_a_pulumi_redis_component():
     def describe_a_redis_cluster():
         def it_has_a_cluster(sut):
             assert sut.cluster
+
+        def it_is_named(sut, name):
+            assert sut.cluster._name == name
+
+        @pulumi.runtime.test
+        def it_has_a_cluster_id(sut, name, stack):
+            return assert_output_equals(sut.cluster.cluster_id, f"{stack}-{name}")
 
         @pulumi.runtime.test
         def it_has_engine_redis(sut):

--- a/deployment/src/tests/test_redis.py
+++ b/deployment/src/tests/test_redis.py
@@ -3,6 +3,7 @@ import os
 import pulumi.runtime
 import pulumi_aws
 import pytest
+from pulumi import Output
 
 from tests.shared import assert_outputs_equal, assert_output_equals
 from tests.mocks import get_pulumi_mocks
@@ -63,6 +64,13 @@ def describe_a_pulumi_redis_component():
         def it_has_port(sut):
             return assert_output_equals(sut.cluster.port, 6379)
 
+        @pulumi.runtime.test
+        def it_has_url(sut):
+            return assert_outputs_equal(sut.get_url(),
+                                        Output.concat('redis://',
+                                                      sut.cluster.cache_nodes[0].address,
+                                                      ':6379'))
+
         def describe_with_defaults():
             @pulumi.runtime.test
             def test_it_has_node_type(sut):
@@ -115,7 +123,6 @@ def describe_a_pulumi_redis_component():
         def it_sets_the_cache_eviction_policy_to_noeviction(sut):
             assert_output_equals(sut.parameter_group.parameters[0].name, "maxmemory-policy")
             assert_output_equals(sut.parameter_group.parameters[0].value, "noeviction")
-
 
     def describe_a_redis_cache_cluster():
         @pytest.fixture

--- a/deployment/src/tests/test_redis.py
+++ b/deployment/src/tests/test_redis.py
@@ -87,3 +87,16 @@ def describe_a_pulumi_redis_component():
             @pulumi.runtime.test
             def it_has_num_cache_nodes(sut, component_arguments):
                 return assert_output_equals(sut.cluster.num_cache_nodes, 2)
+
+    def describe_a_redis_queue_cluster():
+        @pytest.fixture
+        def sut(component_arguments):
+            import strongmind_deployment.redis
+
+            sut = strongmind_deployment.redis.QueueComponent("queue_redis",
+                                                             **component_arguments
+                                                             )
+            return sut
+
+        def it_has_a_parameter_group(sut):
+            assert sut.parameter_group


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-934)

## Purpose 
We need to support the use of Redis as either a queue (for Sidekiq) or as a cache, because the best settings (maxmemory-policy) differ in these two scenarios.

## Approach 
Provide a CacheComponent and QueueComponent that can be included in the RailsComponent by simply passing queue_redis=True and/or cache_redis=True as parameters. You can also provide an entire component in these parameters if you need to scale the Redis up.

## Testing
Unit tests.
Integration tested with the frozen-desserts test application.
