### PR TITLE
(B) SKNK-411: Add env variable for rails deploys for sidekiq pro

### DIFF
--- a/.github/workflows/rails-deploy.yml
+++ b/.github/workflows/rails-deploy.yml
@@ -41,6 +41,7 @@ jobs:
         RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
         CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
         ENVIRONMENT_NAME: ${{ inputs.environment-name }}
+        BUNDLE_GEMS__CONTRIBSYS__COM: ${{ secrets.BUNDLE_GEMS__CONTRIBSYS__COM }}
       run: |
         cd ./infrastructure/
         pulumi login s3://pulumi-state-sm/${{ github.event.repository.name }}


### PR DESCRIPTION
[SKNK-411](https://strongmind.atlassian.net/browse/SKNK-411)

## Purpose 
To use Sidekiq-Pro, we need to set an environment variable

## Approach 
Set the BUNDLE_GEMS__CONTRIBSYS__COM from the org secret in GitHub

## Testing
No testing was done

## Screenshots/Video
N/A


[SKNK-411]: https://strongmind.atlassian.net/browse/SKNK-411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ