### PR TITLE
add tag propagation and tests to ecs tasks.

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -160,6 +160,7 @@ class ContainerComponent(pulumi.ComponentResource):
             cluster=self.ecs_cluster_arn,
             continue_before_steady_state=True,
             assign_public_ip=True,
+            propagate_tags="SERVICE",
             task_definition_args=task_definition_args,
             tags=self.tags,
             opts=pulumi.ResourceOptions(parent=self),

--- a/deployment/src/tests/mocks.py
+++ b/deployment/src/tests/mocks.py
@@ -25,6 +25,7 @@ def get_pulumi_mocks(faker, fake_password=None):
                 outputs = {
                     **args.inputs,
                     "task_definition_args": args.inputs["taskDefinitionArgs"],
+                    "propagate_tags": args.inputs.get("propagateTags"),
                 }
             if args.typ == "aws:rds/cluster:Cluster":
                 outputs = {

--- a/deployment/src/tests/test_container.py
+++ b/deployment/src/tests/test_container.py
@@ -300,6 +300,10 @@ def describe_a_pulumi_containerized_app():
             @pulumi.runtime.test
             def it_creates_a_fargate_service(sut):
                 assert sut.fargate_service
+            
+            @pulumi.runtime.test
+            def it_propagate_tags(sut):
+                return assert_output_equals(sut.fargate_service.propagate_tags, "SERVICE")
 
             @pulumi.runtime.test
             def it_has_the_cluster(sut):


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/DEVOPS-8912)


## Purpose 
AWS billing information for ecs is based on the running tasks. 

## Approach 
Configure the ecs service to propagate the tags to the tasks

## Testing
Ran configuration on global build to test the functionality. Applied same changes to the rails component. 

## Screenshots/Video
(show before/after of the change if possible)
