### PR TITLE
[DEVOPS-9181] Create prototype secrets retrieving into container definition secrets block

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -129,6 +129,9 @@ class ContainerComponent(pulumi.ComponentResource):
             opts=pulumi.ResourceOptions(parent=self),
         )
 
+        sm_secret = self.create_secretmanager_secret(project_stack, self.tags)
+        secrets = self.retrieve_secrets_from_secretmanager(sm_secret)
+
         task_definition_args = awsx.ecs.FargateServiceTaskDefinitionArgs(
             skip_destroy=True,
             family=project_stack,
@@ -291,3 +294,28 @@ class ContainerComponent(pulumi.ComponentResource):
             validation_record_fqdns=[self.cert_validation_record.hostname],
             opts=pulumi.ResourceOptions(parent=self, depends_on=[self.cert_validation_record]),
         )
+
+    def create_secretmanager_secret(self, name, tags):
+        sm_secret = aws.secretsmanager.Secret(
+            f'{name}-secrets',
+            name=name,
+            tags=tags
+        )
+
+        return sm_secret
+
+    def retrieve_secrets_from_secretmanager(self, sm_secret):
+        pretty_secrets = []
+        secret_value = aws.secretsmanager.get_secret_version(
+            secret_id=sm_secret.arn,
+        )
+        secrets = json.loads(secret_value.secret_string)
+
+        for secret in secrets.keys():
+            pretty_secrets.append(
+                {
+                "name": secret,
+                "valueFrom": f"{secret_value.arn}:{secret}::",
+            })
+
+        return pretty_secrets

--- a/deployment/src/tests/mocks.py
+++ b/deployment/src/tests/mocks.py
@@ -55,6 +55,11 @@ def get_pulumi_mocks(faker, fake_password=None):
                     **args.inputs,
                     "arn": f"arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/{faker.word()}",
                 }
+            if args.typ == "aws:secretsmanager/secret:Secret":
+                outputs = {
+                    **args.inputs,
+                    "arn": f"arn:aws:secretsmanager:us-west-2:123456789012:secret/{faker.word()}",
+                }
             if args.typ == "aws:elasticache/cluster:Cluster":
                 outputs = {
                     **args.inputs,
@@ -76,6 +81,11 @@ def get_pulumi_mocks(faker, fake_password=None):
             return [args.name + '_id', outputs]
 
         def call(self, args: pulumi.runtime.MockCallArgs):
+            if args.token == "aws:secretsmanager/getSecretVersion:getSecretVersion":
+                return {
+                    "arn": f"arn:aws:secretsmanager:us-west-2:123456789013:secret/{faker.word()}",
+                    "secretString": f"{{\"{faker.word()}\":\"{faker.password()}\"}}",
+                }
             return {}
 
     return PulumiMocks()

--- a/deployment/src/tests/test_container.py
+++ b/deployment/src/tests/test_container.py
@@ -323,6 +323,7 @@ def describe_a_pulumi_containerized_app():
                     assert container["cpu"] == cpu
                     assert container["memory"] == memory
                     assert container["essential"]
+                    assert container["secrets"]
                     assert container["entryPoint"] == entry_point
                     assert container["portMappings"][0]["containerPort"] == container_port
                     assert container["portMappings"][0]["hostPort"] == container_port


### PR DESCRIPTION
https://strongmind.atlassian.net/browse/DEVOPS-9181

## Purpose 
Canvas Enterprise Deploy: Retrieve Secrets

## Approach 
Create prototype secrets retrieving from ssecretmanager

## Testing
Test on Repository-Dashboard container

## Screenshots/Video
<img width="812" alt="image" src="https://github.com/StrongMind/public-reusable-workflows/assets/57175646/4f0ffd28-5d54-4e27-b41a-6c59e892adbf">
