### PR TITLE
[DEVOPS-9495] Create only one secretsmanager per environment in public-reusable-workflow

### DIFF
--- a/deployment/pyproject.toml
+++ b/deployment/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "strongmind_deployment"
-version = "1.0.29"
+version = "1.0.30"
 
 authors = [
   { name="Belding", email="teambelding@strongmind.com" },

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -47,6 +47,7 @@ class RailsComponent(pulumi.ComponentResource):
         self.db_password = None
         self.web_container = None
         self.worker_container = None
+        self.secret = None
         self.rds_serverless_cluster_instance = None
         self.rds_serverless_cluster = None
         self.kwargs = kwargs
@@ -142,7 +143,7 @@ class RailsComponent(pulumi.ComponentResource):
                                                               "rails server --port 3000 -b 0.0.0.0"])
 
         self.kwargs['entry_point'] = web_entry_point
-        self.kwargs['secrets'] = self.secret.get_secrets(self.secret.sm_secret_version.arn)
+        self.kwargs['secrets'] = self.secret.get_secrets(self.secret.sm_secret.arn)
 
         self.web_container = ContainerComponent("container",
                                                 pulumi.ResourceOptions(parent=self),
@@ -165,7 +166,7 @@ class RailsComponent(pulumi.ComponentResource):
         self.kwargs['app_path'] = self.kwargs.get('worker_app_path')
         self.kwargs['need_load_balancer'] = False
         self.kwargs['ecs_cluster_arn'] = self.web_container.ecs_cluster_arn
-        self.kwargs['secrets'] = self.secret.get_secrets(self.secret.sm_secret_version.arn)
+        self.kwargs['secrets'] = self.secret.get_secrets(self.secret.sm_secret.arn)
         self.worker_container = ContainerComponent("worker",
                                                    pulumi.ResourceOptions(parent=self),
                                                    **self.kwargs

--- a/deployment/src/strongmind_deployment/secretsmanager.py
+++ b/deployment/src/strongmind_deployment/secretsmanager.py
@@ -16,10 +16,11 @@ class SecretsComponent(pulumi.ComponentResource):
 
         self.env_name = os.environ.get('ENVIRONMENT_NAME', 'stage')
         self.formatted_secrets = []
+        self.secret_string = kwargs.get('secret_string', '{}')
 
         project = pulumi.get_project()
         stack = pulumi.get_stack()
-        project_stack = f"{project}-{stack}-devops-9495"
+        project_stack = f"{project}-{stack}"
 
         self.tags = {
             "product": project,
@@ -38,7 +39,7 @@ class SecretsComponent(pulumi.ComponentResource):
         self.sm_secret_version = aws.secretsmanager.SecretVersion(
             f"{project_stack}-secrets-version",
             secret_id=self.sm_secret.arn,
-            secret_string=json.dumps({})
+            secret_string=json.dumps(self.secret_string)
         )
         self.register_outputs({})
     

--- a/deployment/src/strongmind_deployment/secretsmanager.py
+++ b/deployment/src/strongmind_deployment/secretsmanager.py
@@ -1,0 +1,60 @@
+import pulumi
+import pulumi_aws as aws
+from pulumi import Output
+import os
+import json
+
+class SecretsComponent(pulumi.ComponentResource):
+    def __init__(self, name, opts=None, **kwargs):
+        """
+        Resource that creates a SecretsManager secret.
+
+        :param name: The _unique_ name of the resource.
+        :param opts: Not used in this resource, but provided for consistency with Pulumi components.
+        """
+        super().__init__('strongmind:global_build:commons:secretsmanager', name, None, opts)
+
+        self.env_name = os.environ.get('ENVIRONMENT_NAME', 'stage')
+        self.formatted_secrets = []
+
+        project = pulumi.get_project()
+        stack = pulumi.get_stack()
+        project_stack = f"{project}-{stack}-devops-9495"
+
+        self.tags = {
+            "product": project,
+            "repository": project,
+            "service": project,
+            "environment": self.env_name,
+        }
+
+        self.sm_secret = aws.secretsmanager.Secret(
+            f"{project_stack}-secrets",
+            name=f"{project_stack}-secrets",
+            tags=self.tags
+        )
+
+        # put initial dummy secret value
+        self.sm_secret_version = aws.secretsmanager.SecretVersion(
+            f"{project_stack}-secrets-version",
+            secret_id=self.sm_secret.arn,
+            secret_string=json.dumps({})
+        )
+        self.register_outputs({})
+    
+    def get_secrets(self, sm_secret_arn):
+        formatted_secrets = []
+
+        secret_value = aws.secretsmanager.get_secret_version(
+            secret_id=sm_secret_arn,
+        )
+        secrets = json.loads(secret_value.secret_string)
+        for secret in secrets.keys():
+            formatted_secrets.append(
+                {
+                    "name": secret,
+                    "valueFrom": f"{secret_value.arn}:{secret}",
+                }
+            )
+
+        return formatted_secrets

--- a/deployment/src/tests/mocks.py
+++ b/deployment/src/tests/mocks.py
@@ -87,7 +87,7 @@ def get_pulumi_mocks(faker, fake_password=None):
                 outputs = {
                     **args.inputs,
                     "arn": f"arn:aws:secretsmanager:us-west-2:123456789012:secret/{faker.word()}",
-                    "secret_string": f"{{\"{faker.word()}\":\"{faker.password()}\"}}",
+                    "secret_string": "{}",
                 }
             return [args.name + '_id', outputs]
 
@@ -95,7 +95,7 @@ def get_pulumi_mocks(faker, fake_password=None):
             if args.token == "aws:secretsmanager/getSecretVersion:getSecretVersion":
                 return {
                     "arn": f"arn:aws:secretsmanager:us-west-2:123456789013:secret/{faker.word()}",
-                    "secretString": f"{{\"{faker.word()}\":\"{faker.password()}\"}}",
+                    "secretString": "{}",
                 }
             return {}
 

--- a/deployment/src/tests/mocks.py
+++ b/deployment/src/tests/mocks.py
@@ -87,7 +87,7 @@ def get_pulumi_mocks(faker, fake_password=None):
                 outputs = {
                     **args.inputs,
                     "arn": f"arn:aws:secretsmanager:us-west-2:123456789012:secret/{faker.word()}",
-                    "secret_string": f"{{\"delete_me\":\"dummy\"}}",
+                    "secret_string": f"{{\"{faker.word()}\":\"{faker.password()}\"}}",
                 }
             return [args.name + '_id', outputs]
 
@@ -95,7 +95,7 @@ def get_pulumi_mocks(faker, fake_password=None):
             if args.token == "aws:secretsmanager/getSecretVersion:getSecretVersion":
                 return {
                     "arn": f"arn:aws:secretsmanager:us-west-2:123456789013:secret/{faker.word()}",
-                    "secretString": f"{{\"delete_me\":\"dummy\"}}",
+                    "secretString": f"{{\"{faker.word()}\":\"{faker.password()}\"}}",
                 }
             return {}
 

--- a/deployment/src/tests/test_container.py
+++ b/deployment/src/tests/test_container.py
@@ -324,7 +324,6 @@ def describe_a_pulumi_containerized_app():
                     assert container["memory"] == memory
                     assert container["essential"]
                     assert container["entryPoint"] == entry_point
-                    assert container["secrets"]
                     assert container["portMappings"][0]["containerPort"] == container_port
                     assert container["portMappings"][0]["hostPort"] == container_port
                     assert container["logConfiguration"]["logDriver"] == "awslogs"

--- a/deployment/src/tests/test_container.py
+++ b/deployment/src/tests/test_container.py
@@ -58,6 +58,12 @@ def describe_a_pulumi_containerized_app():
         return {
             "ENVIRONMENT_NAME": environment,
         }
+    
+    @pytest.fixture
+    def secrets(faker):
+        return [{
+            faker.word(): faker.password(),
+        }]
 
     @pytest.fixture
     def load_balancer_arn(faker):
@@ -113,6 +119,7 @@ def describe_a_pulumi_containerized_app():
             entry_point,
             container_image,
             env_vars,
+            secrets,
             load_balancer_arn,
             target_group_arn,
             zone_id,
@@ -128,6 +135,7 @@ def describe_a_pulumi_containerized_app():
                                                                   entry_point=entry_point,
                                                                   container_image=container_image,
                                                                   env_vars=env_vars,
+                                                                  secrets=secrets,
                                                                   load_balancer_arn=load_balancer_arn,
                                                                   target_group_arn=target_group_arn,
                                                                   zone_id=zone_id,

--- a/deployment/src/tests/test_container.py
+++ b/deployment/src/tests/test_container.py
@@ -331,6 +331,7 @@ def describe_a_pulumi_containerized_app():
                     assert container["cpu"] == cpu
                     assert container["memory"] == memory
                     assert container["essential"]
+                    assert container["secrets"]
                     assert container["entryPoint"] == entry_point
                     assert container["portMappings"][0]["containerPort"] == container_port
                     assert container["portMappings"][0]["hostPort"] == container_port

--- a/deployment/src/tests/test_rails.py
+++ b/deployment/src/tests/test_rails.py
@@ -83,6 +83,12 @@ def describe_a_pulumi_rails_app():
     @pytest.fixture
     def target_group_arn(faker):
         return f"arn:aws:elasticloadbalancing:us-west-2:{faker.random_int()}:targetgroup/{faker.word()}/{faker.random_int()}"
+    
+    #@pytest.fixture
+    #def secrets(faker):
+    #    return [{
+    #        faker.word(): faker.password(),
+    #    }]
 
     @pytest.fixture
     def domain_validation_options(faker):
@@ -153,7 +159,7 @@ def describe_a_pulumi_rails_app():
             "zone_id": zone_id,
             "env_vars": {
                 "ENVIRONMENT_NAME": environment
-            }
+            },
         }
 
         return kwargs
@@ -168,11 +174,26 @@ def describe_a_pulumi_rails_app():
                                                          )
         return sut
 
+    @pulumi.runtime.test
     def it_exists(sut):
         assert sut
 
+    @pulumi.runtime.test
     def it_has_no_dynamo_tables(sut):
         assert sut.dynamo_tables == []
+
+    def describe_secretmanager_secret():
+        @pulumi.runtime.test
+        def it_has_a_secret(sut):
+            assert sut.secret.sm_secret
+        
+        @pulumi.runtime.test
+        def it_has_a_secret_version(sut):
+            assert sut.secret.sm_secret_version
+        
+        @pulumi.runtime.test
+        def it_has_a_sm_secret_version_secret_string(sut):
+            return assert_output_equals(sut.secret.sm_secret_version.secret_string, "{}")
 
     def describe_a_rds_postgres_cluster():
         @pulumi.runtime.test

--- a/deployment/src/tests/test_rails.py
+++ b/deployment/src/tests/test_rails.py
@@ -83,12 +83,6 @@ def describe_a_pulumi_rails_app():
     @pytest.fixture
     def target_group_arn(faker):
         return f"arn:aws:elasticloadbalancing:us-west-2:{faker.random_int()}:targetgroup/{faker.word()}/{faker.random_int()}"
-    
-    #@pytest.fixture
-    #def secrets(faker):
-    #    return [{
-    #        faker.word(): faker.password(),
-    #    }]
 
     @pytest.fixture
     def domain_validation_options(faker):

--- a/deployment/src/tests/test_secretsmanager.py
+++ b/deployment/src/tests/test_secretsmanager.py
@@ -1,0 +1,115 @@
+import os
+import json
+
+import pulumi.runtime
+import pulumi_aws
+import pytest
+from pulumi import Output
+
+from tests.shared import assert_outputs_equal, assert_output_equals
+from tests.mocks import get_pulumi_mocks
+
+
+def describe_a_pulumi_secretsmanager_component():
+    @pytest.fixture
+    def app_name(faker):
+        return faker.word()
+
+    @pytest.fixture
+    def environment(faker):
+        return faker.word()
+
+    @pytest.fixture
+    def stack(faker, app_name, environment):
+        return f"{environment}"
+
+    @pytest.fixture
+    def pulumi_mocks(faker):
+        return get_pulumi_mocks(faker)
+
+    @pytest.fixture
+    def name(faker):
+        return faker.word()
+
+    @pytest.fixture
+    def component_arguments():
+        return {}
+
+    @pytest.fixture
+    def sut(pulumi_set_mocks,
+            component_arguments,
+            name):
+        import strongmind_deployment.secretsmanager
+
+        sut = strongmind_deployment.secretsmanager.SecretsComponent(name,
+                                                         **component_arguments
+                                                         )
+        return sut
+
+    @pulumi.runtime.test
+    def it_exists(sut):
+        assert sut
+
+    @pulumi.runtime.test
+    def it_is_a_component_resource(sut):
+        assert isinstance(sut, pulumi.ComponentResource)
+
+    def describe_a_secretsmanager_secret():
+        @pulumi.runtime.test
+        def it_registers_with_pulumi_with_its_type_string(sut):
+            assert sut._type == "strongmind:global_build:commons:secretsmanager"
+
+        @pulumi.runtime.test
+        def it_has_a_sm_secret(sut):
+            assert sut.sm_secret
+
+        @pulumi.runtime.test
+        def it_has_sm_secret_version(sut):
+            assert sut.sm_secret_version
+
+        @pulumi.runtime.test
+        def it_is_named(sut, name):
+            assert sut._name == name
+
+        @pulumi.runtime.test
+        def it_has_a_sm_secret_name(sut, name, app_name, stack):
+            return assert_output_equals(sut.sm_secret.name, f"{app_name}-{stack}-secrets")
+
+        @pulumi.runtime.test
+        def it_has_a_sm_secret_version_secret_string(sut):
+            return assert_output_equals(sut.sm_secret_version.secret_string, "{}")
+
+        @pulumi.runtime.test
+        def it_has_a_get_secrets_method(sut):
+            assert sut.get_secrets
+
+        def descride_get_secrets_method():
+            @pytest.fixture
+            def secret_string(faker):
+                return f"{{\"{faker.word()}\":\"{faker.password()}\"}}"
+
+            @pytest.fixture
+            def secret_arn(faker):
+                return f"arn:aws:secretsmanager:us-west-2:{faker.random_int()}:secret:{faker.word()}-{faker.random_int()}"
+
+            @pytest.fixture
+            def sut(component_arguments,
+                    name,
+                    secret_string):
+                import strongmind_deployment.secretsmanager
+
+                sut = strongmind_deployment.secretsmanager.SecretsComponent(name,
+                                                        **component_arguments,
+                                                        secret_string=secret_string,
+                                                        )
+                return sut
+            
+            @pulumi.runtime.test
+            def it_should_return_secrets(sut, secret_string):
+                secret_arn = sut.sm_secret.arn
+                secrets = sut.get_secrets(secret_arn)
+                assert secrets
+                assert isinstance(secrets, dict)
+                assert len(secrets) > 0
+                assert all([a["name"] == b["name"] for a, b in zip(secrets, secret_string)])
+                return assert_output_equals(sut._secrets_string, secret_string)


### PR DESCRIPTION
https://strongmind.atlassian.net/browse/DEVOPS-9495

## Purpose 
Create only one secretsmanager per environment in public-reusable-workflow

## Approach 
Write separate resource component to work with the secretsmanager
Write tests for new secretsmanager component

## Testing
Locally on Frozen Desserts

## Screenshots/Video
TaskDefinition revision 21 (with empty secrets)
<img width="326" alt="image" src="https://github.com/StrongMind/public-reusable-workflows/assets/57175646/965ec32e-2402-4da7-b287-4ae71e867e7b">
<img width="661" alt="image" src="https://github.com/StrongMind/public-reusable-workflows/assets/57175646/116b2076-b25d-4443-9b9c-3223a3f06145">

TaskDefinition revision 22 (with test secrets)
<img width="299" alt="image" src="https://github.com/StrongMind/public-reusable-workflows/assets/57175646/b1d246bb-3325-465b-96a4-812f08d5517f">
<img width="687" alt="image" src="https://github.com/StrongMind/public-reusable-workflows/assets/57175646/5aec7acc-7e20-42ad-b3b5-a43e70404a0b">

