### PR TITLE
BEL-1353 Provide option to use md5 hashed postgres passwords

### DIFF
--- a/deployment/pyproject.toml
+++ b/deployment/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "strongmind_deployment"
-version = "1.1.0"
+version = "1.1.2"
 
 authors = [
   { name="Belding", email="teambelding@strongmind.com" },

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -40,6 +40,7 @@ class RailsComponent(pulumi.ComponentResource):
         :key worker_memory: The amount of memory (in MiB) to allow the worker container to use. Defaults to 512.
         :key worker_app_path: The path to the Rails application for the worker. Defaults to `./`.
         :key dynamo_tables: A list of DynamoDB tables to create. Defaults to `[]`. Each table is a DynamoComponent.
+        :key md5_hash_db_password: Whether to MD5 hash the database password. Defaults to False.
         """
         super().__init__('strongmind:global_build:commons:rails', name, None, opts)
         self.need_worker = None

--- a/deployment/src/tests/shared.py
+++ b/deployment/src/tests/shared.py
@@ -3,7 +3,12 @@ from pulumi import Output
 
 def assert_output_equals(output, expected):
     def compare(value):
-        assert value == expected
+        try:
+            assert value == expected
+        except AssertionError:
+            print(f"Expected: {expected}")
+            print(f"Actual: {value}")
+            raise
 
     return output.apply(compare)
 
@@ -11,6 +16,11 @@ def assert_output_equals(output, expected):
 def assert_outputs_equal(expected_output, actual_output):
     def compare(args):
         expected, actual = args
-        assert expected == actual
+        try:
+            assert expected == actual
+        except AssertionError:
+            print(f"Expected: {expected}")
+            print(f"Actual: {actual}")
+            raise
 
     return Output.all(expected_output, actual_output).apply(compare)

--- a/deployment/src/tests/test_rails.py
+++ b/deployment/src/tests/test_rails.py
@@ -234,7 +234,7 @@ def describe_a_pulumi_rails_app():
                 assert actual_secrets == [
                     {
                         'name': secret_key_1,
-                         'valueFrom': f'arn:aws:secretsmanager:us-west-2:123456789013:secret/my-secrets:{secret_key_1}::'
+                        'valueFrom': f'arn:aws:secretsmanager:us-west-2:123456789013:secret/my-secrets:{secret_key_1}::'
                     },
                     {
                         'name': secret_key_2,
@@ -249,13 +249,16 @@ def describe_a_pulumi_rails_app():
 
         @pulumi.runtime.test
         def it_has_an_md5_password_hashed_with_the_username_as_a_salt(sut):
-            def check_password(pwd):
+            def check_password(args):
+                pwd, hashed_pwd = args
                 m = hashlib.md5()
-                m.update(sut.db_password)
-                assert pwd.startswith('md5')
-                assert pwd.endswith(sut.db_username.result)
 
-            return sut.db_password.result.apply(check_password)
+                string_to_hash = f"{pwd}{sut.db_username}"
+                m.update(string_to_hash.encode())
+                assert hashed_pwd.startswith('md5')
+                assert hashed_pwd == f"md5{m.hexdigest()}"
+
+            return pulumi.Output.all(sut.db_password.result, sut.hashed_password).apply(check_password)
 
         @pulumi.runtime.test
         def it_has_a_password_with_30_chars(sut):
@@ -295,8 +298,8 @@ def describe_a_pulumi_rails_app():
                                         f'{app_name}-{stack}'.replace('-', '_'))
 
         @pulumi.runtime.test
-        def it_sets_the_master_password(sut, master_db_password):
-            return assert_output_equals(sut.rds_serverless_cluster.master_password, master_db_password)
+        def it_sets_the_master_password(sut):
+            return assert_outputs_equal(sut.rds_serverless_cluster.master_password, sut.hashed_password)
 
         @pulumi.runtime.test
         def it_turns_on_deletion_protection(sut):

--- a/deployment/src/tests/test_rails.py
+++ b/deployment/src/tests/test_rails.py
@@ -1,4 +1,5 @@
 import json
+import hashlib
 import os
 
 import pulumi.runtime
@@ -245,6 +246,16 @@ def describe_a_pulumi_rails_app():
         @pulumi.runtime.test
         def it_has_a_password(sut):
             assert sut.db_password
+
+        @pulumi.runtime.test
+        def it_has_an_md5_password_hashed_with_the_username_as_a_salt(sut):
+            def check_password(pwd):
+                m = hashlib.md5()
+                m.update(sut.db_password)
+                assert pwd.startswith('md5')
+                assert pwd.endswith(sut.db_username.result)
+
+            return sut.db_password.result.apply(check_password)
 
         @pulumi.runtime.test
         def it_has_a_password_with_30_chars(sut):

--- a/deployment/src/tests/test_rails.py
+++ b/deployment/src/tests/test_rails.py
@@ -299,7 +299,7 @@ def describe_a_pulumi_rails_app():
 
         @pulumi.runtime.test
         def it_sets_the_master_password(sut):
-            return assert_outputs_equal(sut.rds_serverless_cluster.master_password, sut.hashed_password)
+            return assert_outputs_equal(sut.rds_serverless_cluster.master_password, sut.db_password.result)
 
         @pulumi.runtime.test
         def it_turns_on_deletion_protection(sut):
@@ -333,7 +333,7 @@ def describe_a_pulumi_rails_app():
                 sut.web_container.env_vars["DATABASE_URL"],
                 sut.rds_serverless_cluster.endpoint,
                 sut.rds_serverless_cluster.master_username,
-                sut.rds_serverless_cluster.master_password
+                sut.db_password.result
             ).apply(check_ecs_environment)
 
         @pulumi.runtime.test
@@ -370,8 +370,18 @@ def describe_a_pulumi_rails_app():
 
             return pulumi.Output.all(
                 sut.web_container.env_vars["DB_PASSWORD"],
-                sut.rds_serverless_cluster.master_password
+                sut.db_password.result
             ).apply(check_ecs_environment)
+
+        def describe_with_md5_passwords_on():
+            @pytest.fixture
+            def component_kwargs(component_kwargs):
+                component_kwargs['md5_hash_db_password'] = True
+                return component_kwargs
+
+            @pulumi.runtime.test
+            def it_sets_the_master_password(sut):
+                return assert_outputs_equal(sut.rds_serverless_cluster.master_password, sut.hashed_password)
 
     def describe_a_rds_postgres_cluster_instance():
         @pulumi.runtime.test


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-1353)

## Purpose 
For Canvas, we are on old ubuntu base images that don't support the latest postgres libraries, so we need to use MD5 hashed passwords rather than SCRAM. This should enable that option.

## Approach 
Optionally set the master password to the MD5 hashed version of the actual password.

## Testing
Unit tests.
Tried it with frozen desserts - was able to connect via Data Grip with the option on or off using the same password.

