### PR TITLE
BEL-1369 Allow projects to have a custom health check path

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -12,6 +12,23 @@ from pulumi_cloudflare import get_zone, Record
 
 class ContainerComponent(pulumi.ComponentResource):
     def __init__(self, name, opts=None, **kwargs):
+        """
+        Resource that produces a containerized application running on AWS Fargate.
+
+        :param name: The _unique_ name of the resource.
+        :param opts: A bag of optional settings that control this resource's behavior.
+        :key need_load_balancer: Whether to create a load balancer for the container. Defaults to True.
+        :key container_image: The Docker image to use for the container. Required.
+        :key container_port: The port to expose on the container. Defaults to 3000.
+        :key env_vars: A dictionary of environment variables to pass to the Rails application.
+        :key entry_point: The entry point for the container.
+        :key cpu: The number of CPU units to reserve for the container. Defaults to 256.
+        :key memory: The amount of memory (in MiB) to allow the web container to use. Defaults to 512.
+        :key secrets: A list of secrets to pass to the container. Each secret is a dictionary with the following keys:
+        - name: The name of the secret.
+        - value_from: The ARN of the secret.
+        :key custom_health_check_path: The path to use for the health check. Defaults to `/up`.
+        """
         super().__init__('strongmind:global_build:commons:container', name, None, opts)
 
         self.target_group = None
@@ -25,7 +42,6 @@ class ContainerComponent(pulumi.ComponentResource):
         self.cname_record = None
         self.need_load_balancer = kwargs.get('need_load_balancer', True)
         self.container_image = kwargs.get('container_image')
-        self.app_path = kwargs.get('app_path', './')
         self.container_port = kwargs.get('container_port', 3000)
         self.cpu = kwargs.get('cpu', 256)
         self.memory = kwargs.get("memory", 512)

--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -175,6 +175,7 @@ class ContainerComponent(pulumi.ComponentResource):
 
     def setup_load_balancer(self, kwargs, project, project_stack):
         default_vpc = awsx.ec2.DefaultVpc("default_vpc")
+        health_check_path = kwargs.get('custom_health_check_path', '/up')
 
         self.target_group = aws.lb.TargetGroup(
             "targetgroup",
@@ -185,7 +186,7 @@ class ContainerComponent(pulumi.ComponentResource):
             vpc_id=default_vpc.vpc_id,
             health_check=aws.lb.TargetGroupHealthCheckArgs(
                 enabled=True,
-                path="/up",
+                path=health_check_path,
                 port=str(self.container_port),
                 protocol="HTTP",
                 matcher="200",

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -36,15 +36,16 @@ class RailsComponent(pulumi.ComponentResource):
         :key worker_entry_point: The entry point for the worker container. Defaults to `["sh", "-c", "bundle exec sidekiq"]`
         :key cpu: The number of CPU units to reserve for the web container. Defaults to 256.
         :key memory: The amount of memory (in MiB) to allow the web container to use. Defaults to 512.
-        :key app_path: The path to the Rails application for the web. Defaults to `./`.
         :key worker_cpu: The number of CPU units to reserve for the worker container. Defaults to 256.
         :key worker_memory: The amount of memory (in MiB) to allow the worker container to use. Defaults to 512.
-        :key worker_app_path: The path to the Rails application for the worker. Defaults to `./`.
         :key dynamo_tables: A list of DynamoDB tables to create. Defaults to `[]`. Each table is a DynamoComponent.
         :key md5_hash_db_password: Whether to MD5 hash the database password. Defaults to False.
         :key storage: Whether to create an S3 bucket for the Rails application. Defaults to False.
+        :key custom_health_check_path: The path to use for the health check. Defaults to `/up`.
         """
         super().__init__('strongmind:global_build:commons:rails', name, None, opts)
+        self.queue_redis = None
+        self.cache_redis = None
         self.storage = None
         self.need_worker = None
         self.cname_record = None
@@ -170,7 +171,6 @@ class RailsComponent(pulumi.ComponentResource):
         self.kwargs['entry_point'] = worker_entry_point
         self.kwargs['cpu'] = self.kwargs.get('worker_cpu')
         self.kwargs['memory'] = self.kwargs.get('worker_memory')
-        self.kwargs['app_path'] = self.kwargs.get('worker_app_path')
         self.kwargs['need_load_balancer'] = False
         self.kwargs['ecs_cluster_arn'] = self.web_container.ecs_cluster_arn
         self.kwargs['secrets'] = self.secret.get_secrets()  # pragma: no cover


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-1369)

## Purpose 
While I think we want to standardize on `/up` for everything moving forward, canvas uses `/health_check` - perhaps we should just change canvas but for now I'm thinking this option is reasonable.

## Approach 
Allow a `custom_health_check_path` to be passed to the RailsComponent (or ContainerComponent).

## Testing
Unit tests. Testing with stage-canvas.
