### PR TITLE
Devops 9613 rds snapshot retention

### DIFF
--- a/deployment/pyproject.toml
+++ b/deployment/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "strongmind_deployment"
-version = "1.1.6"
+version = "1.1.7"
 
 authors = [
   { name="Belding", email="teambelding@strongmind.com" },

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -251,6 +251,7 @@ class RailsComponent(pulumi.ComponentResource):
             master_password=master_db_password,
             deletion_protection=True,
             skip_final_snapshot=False,
+            backup_retention_period=14,
             serverlessv2_scaling_configuration=aws.rds.ClusterServerlessv2ScalingConfigurationArgs(
                 min_capacity=0.5,
                 max_capacity=16,

--- a/deployment/src/tests/test_rails.py
+++ b/deployment/src/tests/test_rails.py
@@ -344,6 +344,10 @@ def describe_a_pulumi_rails_app():
         @pulumi.runtime.test
         def it_sets_skip_final_snapshot_to_false(sut):
             return assert_output_equals(sut.rds_serverless_cluster.skip_final_snapshot, False)
+        
+        @pulumi.runtime.test
+        def it_sets_the_backup_retention_period_to_14_days(sut):
+            return assert_output_equals(sut.rds_serverless_cluster.backup_retention_period, 14)
 
         @pulumi.runtime.test
         def it_sets_a_serverlessv2_scaling_configuration(sut):


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/DEVOPS-9613)


## Purpose 
Ensure that RDS databases are taking snapshots and that they make a final snapshot upon deletion.

## Approach 
Final snapshot was already in place, updated the retention to be 14 days (changeable) as the default was 1 day. 

## Testing
Pytest passed the code changes. Also tested on CMS using global build with no issues. 
