### PR TITLE
BEL-1377 Allow overriding execution entry point

### DIFF
--- a/deployment/pyproject.toml
+++ b/deployment/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "strongmind_deployment"
-version = "1.1.11"
+version = "1.1.12"
 
 authors = [
   { name="Belding", email="teambelding@strongmind.com" },

--- a/deployment/pyproject.toml
+++ b/deployment/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "strongmind_deployment"
-version = "1.1.10"
+version = "1.1.11"
 
 authors = [
   { name="Belding", email="teambelding@strongmind.com" },

--- a/deployment/pyproject.toml
+++ b/deployment/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "strongmind_deployment"
-version = "1.1.9"
+version = "1.1.10"
 
 authors = [
   { name="Belding", email="teambelding@strongmind.com" },

--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -22,6 +22,7 @@ class ContainerComponent(pulumi.ComponentResource):
         :key container_port: The port to expose on the container. Defaults to 3000.
         :key env_vars: A dictionary of environment variables to pass to the Rails application.
         :key entry_point: The entry point for the container.
+        :key command: The command to run when the container starts.
         :key cpu: The number of CPU units to reserve for the container. Defaults to 256.
         :key memory: The amount of memory (in MiB) to allow the web container to use. Defaults to 512.
         :key secrets: A list of secrets to pass to the container. Each secret is a dictionary with the following keys:
@@ -46,6 +47,7 @@ class ContainerComponent(pulumi.ComponentResource):
         self.cpu = kwargs.get('cpu', 256)
         self.memory = kwargs.get("memory", 512)
         self.entry_point = kwargs.get('entry_point')
+        self.command = kwargs.get('command')
         self.env_vars = kwargs.get('env_vars', {})
         self.secrets = kwargs.get('secrets', [])
         self.kwargs = kwargs
@@ -167,6 +169,7 @@ class ContainerComponent(pulumi.ComponentResource):
                 cpu=self.cpu,
                 memory=self.memory,
                 entry_point=self.entry_point,
+                command=self.command,
                 essential=True,
                 port_mappings=port_mappings,
                 secrets=self.secrets,

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -29,6 +29,8 @@ class RailsComponent(pulumi.ComponentResource):
         :key env_vars: A dictionary of environment variables to pass to the Rails application.
         :key queue_redis: Either True to create a default queue Redis instance or a RedisComponent to use. Defaults to True if sidekiq is in the Gemfile.
         :key cache_redis: Either True to create a default cache Redis instance or a RedisComponent to use.
+        :key execution_entry_point: The entry point for the pre-deployment execution container. Defaults to ["sh", "-c",
+                                      "bundle exec rails db:prepare db:migrate db:seed && echo 'Migrations complete'"].
         :key web_entry_point: The entry point for the web container. Defaults to the ENTRYPOINT in the Dockerfile.
         :key need_worker: Whether to create a worker container. Defaults to True if sidekiq is in the Gemfile.
         :key worker_entry_point: The entry point for the worker container. Defaults to `["sh", "-c", "bundle exec sidekiq"]`
@@ -154,8 +156,11 @@ class RailsComponent(pulumi.ComponentResource):
         self.kwargs['secrets'] = self.secret.get_secrets()  # pragma: no cover
         self.kwargs['container_image'] = container_image
 
-        self.kwargs['entry_point'] = ["sh", "-c",
-                                      "bundle exec rails db:migrate && echo 'Migrations complete'"]
+        execution_entry_point = self.kwargs.get("execution_entry_point",
+                                                ["sh", "-c",
+                                                 "bundle exec rails db:prepare db:migrate db:seed && "
+                                                 "echo 'Migrations complete'"])
+        self.kwargs['entry_point'] = execution_entry_point
         self.migration_container = ContainerComponent("migration",
                                                       need_load_balancer=False,
                                                       desired_count=0,

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -29,7 +29,7 @@ class RailsComponent(pulumi.ComponentResource):
         :key env_vars: A dictionary of environment variables to pass to the Rails application.
         :key queue_redis: Either True to create a default queue Redis instance or a RedisComponent to use. Defaults to True if sidekiq is in the Gemfile.
         :key cache_redis: Either True to create a default cache Redis instance or a RedisComponent to use.
-        :key execution_entry_point: The entry point for the pre-deployment execution container. Defaults to ["sh", "-c",
+        :key execution_cmd: The command for the pre-deployment execution container. Defaults to ["sh", "-c",
                                       "bundle exec rails db:prepare db:migrate db:seed && echo 'Migrations complete'"].
         :key web_entry_point: The entry point for the web container. Defaults to the ENTRYPOINT in the Dockerfile.
         :key need_worker: Whether to create a worker container. Defaults to True if sidekiq is in the Gemfile.
@@ -157,11 +157,14 @@ class RailsComponent(pulumi.ComponentResource):
         self.kwargs['secrets'] = self.secret.get_secrets()  # pragma: no cover
         self.kwargs['container_image'] = container_image
 
-        execution_entry_point = self.kwargs.get("execution_entry_point",
+        execution_entry_point = self.kwargs.get("execution_entry_point", [])
+        self.kwargs['entry_point'] = execution_entry_point
+
+        execution_cmd = self.kwargs.get("execution_cmd",
                                                 ["sh", "-c",
                                                  "bundle exec rails db:prepare db:migrate db:seed && "
                                                  "echo 'Migrations complete'"])
-        self.kwargs['entry_point'] = execution_entry_point
+        self.kwargs['command'] = execution_cmd
         self.migration_container = ContainerComponent("migration",
                                                       need_load_balancer=False,
                                                       desired_count=0,

--- a/deployment/src/tests/test_container.py
+++ b/deployment/src/tests/test_container.py
@@ -46,6 +46,10 @@ def describe_a_pulumi_containerized_app():
         return f'./{faker.word()}'
 
     @pytest.fixture
+    def command(faker):
+        return f'./{faker.word()}'
+
+    @pytest.fixture
     def aws_account_id(faker):
         return faker.random_int()
 
@@ -117,6 +121,7 @@ def describe_a_pulumi_containerized_app():
                          cpu,
                          memory,
                          entry_point,
+                         command,
                          container_image,
                          env_vars,
                          secrets,
@@ -132,6 +137,7 @@ def describe_a_pulumi_containerized_app():
             "cpu": cpu,
             "memory": memory,
             "entry_point": entry_point,
+            "command": command,
             "container_image": container_image,
             "env_vars": env_vars,
             "secrets": secrets,
@@ -346,7 +352,7 @@ def describe_a_pulumi_containerized_app():
                                          sut.ecs_cluster.arn).apply(check_cluster)
 
             @pulumi.runtime.test
-            def it_has_task_definition(sut, container_port, cpu, memory, entry_point, stack, app_name, secrets):
+            def it_has_task_definition(sut, container_port, cpu, memory, entry_point, command, stack, app_name, secrets):
                 def check_task_definition(args):
                     task_definition_dict = args[0]
                     container = task_definition_dict["container"]
@@ -355,6 +361,7 @@ def describe_a_pulumi_containerized_app():
                     assert container["essential"]
                     assert container["secrets"] == secrets
                     assert container["entryPoint"] == entry_point
+                    assert container["command"] == command
                     assert container["portMappings"][0]["containerPort"] == container_port
                     assert container["portMappings"][0]["hostPort"] == container_port
                     assert container["logConfiguration"]["logDriver"] == "awslogs"

--- a/deployment/src/tests/test_rails.py
+++ b/deployment/src/tests/test_rails.py
@@ -58,7 +58,7 @@ def describe_a_pulumi_rails_app():
         return ["sh", "-c", "bundle exec sidekiq"]
 
     @pytest.fixture
-    def execution_container_entry_point():
+    def execution_container_cmd():
         return ["sh", "-c",
                 "bundle exec rails db:prepare db:migrate db:seed && "
                 "echo 'Migrations complete'"]
@@ -513,22 +513,22 @@ def describe_a_pulumi_rails_app():
             assert sut.web_container.entry_point == container_entry_point
 
         @pulumi.runtime.test
-        def it_uses_default_entry_point_for_execution(sut, execution_container_entry_point):
-            assert sut.migration_container.entry_point == execution_container_entry_point
+        def it_uses_empty_entry_point_for_execution(sut):
+            assert sut.migration_container.entry_point == []
 
-        def describe_with_custom_execution_entry_point():
+        def describe_with_custom_execution_cmd():
             @pytest.fixture
-            def execution_container_entry_point():
+            def execution_container_cmd():
                 return ["sh", "-c", "bundle exec rails db:migrate"]
 
             @pytest.fixture
-            def component_kwargs(component_kwargs, execution_container_entry_point):
-                component_kwargs['execution_entry_point'] = execution_container_entry_point
+            def component_kwargs(component_kwargs, execution_container_cmd):
+                component_kwargs['execution_cmd'] = execution_container_cmd
                 return component_kwargs
 
             @pulumi.runtime.test
-            def it_uses_custom_entry_point_for_execution(sut, execution_container_entry_point):
-                assert sut.migration_container.entry_point == execution_container_entry_point
+            def it_uses_custom_command_for_execution(sut, execution_container_cmd):
+                assert sut.migration_container.command == execution_container_cmd
 
         def describe_with_need_worker_set():
             @pytest.fixture

--- a/deployment/src/tests/test_rails.py
+++ b/deployment/src/tests/test_rails.py
@@ -58,6 +58,12 @@ def describe_a_pulumi_rails_app():
         return ["sh", "-c", "bundle exec sidekiq"]
 
     @pytest.fixture
+    def execution_container_entry_point():
+        return ["sh", "-c",
+                "bundle exec rails db:prepare db:migrate db:seed && "
+                "echo 'Migrations complete'"]
+
+    @pytest.fixture
     def cpu(faker):
         return faker.random_int()
 
@@ -344,7 +350,7 @@ def describe_a_pulumi_rails_app():
         @pulumi.runtime.test
         def it_sets_skip_final_snapshot_to_false(sut):
             return assert_output_equals(sut.rds_serverless_cluster.skip_final_snapshot, False)
-        
+
         @pulumi.runtime.test
         def it_sets_the_backup_retention_period_to_14_days(sut):
             return assert_output_equals(sut.rds_serverless_cluster.backup_retention_period, 14)
@@ -493,6 +499,24 @@ def describe_a_pulumi_rails_app():
         @pulumi.runtime.test
         def it_uses_rails_entry_point(sut, container_entry_point):
             assert sut.web_container.entry_point == container_entry_point
+
+        @pulumi.runtime.test
+        def it_uses_default_entry_point_for_execution(sut, execution_container_entry_point):
+            assert sut.migration_container.entry_point == execution_container_entry_point
+
+        def describe_with_custom_execution_entry_point():
+            @pytest.fixture
+            def execution_container_entry_point():
+                return ["sh", "-c", "bundle exec rails db:migrate"]
+
+            @pytest.fixture
+            def component_kwargs(component_kwargs, execution_container_entry_point):
+                component_kwargs['execution_entry_point'] = execution_container_entry_point
+                return component_kwargs
+
+            @pulumi.runtime.test
+            def it_uses_custom_entry_point_for_execution(sut, execution_container_entry_point):
+                assert sut.migration_container.entry_point == execution_container_entry_point
 
         def describe_with_need_worker_set():
             @pytest.fixture


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-1377)

## Purpose 
Some systems (Canvas) need to run specific pieces at deployment (just db:migrate) whereas the default should be prepare/migrate/seed.

## Approach 
Default to prepare/migrate/seed and allow keyword argument to override.

## Testing
Unit tests.
