### PR TITLE
Bel 1439 allow restore from snapshot

### DIFF
--- a/deployment/pyproject.toml
+++ b/deployment/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "strongmind_deployment"
-version = "1.1.8"
+version = "1.1.9"
 
 authors = [
   { name="Belding", email="teambelding@strongmind.com" },

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -61,6 +61,7 @@ class RailsComponent(pulumi.ComponentResource):
         self.rds_serverless_cluster_instance = None
         self.rds_serverless_cluster = None
         self.kwargs = kwargs
+        self.snapshot_identifier = self.kwargs.get('snapshot_identifier', None)
         self.dynamo_tables = self.kwargs.get('dynamo_tables', [])
         self.env_vars = self.kwargs.get('env_vars', {})
 
@@ -257,6 +258,7 @@ class RailsComponent(pulumi.ComponentResource):
                 min_capacity=0.5,
                 max_capacity=16,
             ),
+            snapshot_identifier=self.snapshot_identifier,
             tags=self.tags,
             opts=pulumi.ResourceOptions(parent=self,
                                         protect=True),

--- a/deployment/src/tests/test_rails.py
+++ b/deployment/src/tests/test_rails.py
@@ -423,6 +423,18 @@ def describe_a_pulumi_rails_app():
             def it_sets_the_master_password(sut):
                 return assert_outputs_equal(sut.rds_serverless_cluster.master_password, sut.hashed_password)
 
+        def describe_when_given_a_snapshot_to_restore_from():
+            @pytest.fixture
+            def component_kwargs(component_kwargs, faker):
+                component_kwargs['snapshot_identifier'] = \
+                    f'arn:aws:rds:us-west-2:448312246740:cluster-snapshot:{faker.word()}'
+                return component_kwargs
+
+            @pulumi.runtime.test
+            def it_restores_the_snapshot(sut):
+                return assert_output_equals(sut.rds_serverless_cluster.snapshot_identifier,
+                                            sut.snapshot_identifier)
+
     def describe_a_rds_postgres_cluster_instance():
         @pulumi.runtime.test
         def it_creates_a_aurora_postgres_cluster_instance(sut, stack, app_name):


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-1439)

## Purpose 
So that we can migrate canvas instances, allow database clusters to be restored from cluster snapshots

## Approach 
Send a `snapshot_identifier` sent to the RailsComponent to its RDS cluster

## Testing
Unit tests
