### PR TITLE
BEL-1439 Ignore database name and master username changes

### DIFF
--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -274,8 +274,7 @@ class RailsComponent(pulumi.ComponentResource):
             kms_key_id=self.kms_key_id,
             storage_encrypted=bool(self.kms_key_id),
             tags=self.tags,
-            opts=pulumi.ResourceOptions(parent=self,
-                                        protect=True),
+            opts=pulumi.ResourceOptions(parent=self, ignore_changes=[ 'database_name', 'master_username'])
         )
         self.rds_serverless_cluster_instance = aws.rds.ClusterInstance(
             'rds_serverless_cluster_instance',

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -164,9 +164,9 @@ class RailsComponent(pulumi.ComponentResource):
         self.kwargs['entry_point'] = execution_entry_point
 
         execution_cmd = self.kwargs.get("execution_cmd",
-                                                ["sh", "-c",
-                                                 "bundle exec rails db:prepare db:migrate db:seed && "
-                                                 "echo 'Migrations complete'"])
+                                        ["sh", "-c",
+                                         "bundle exec rails db:prepare db:migrate db:seed && "
+                                         "echo 'Migrations complete'"])
         self.kwargs['command'] = execution_cmd
         self.migration_container = ContainerComponent("migration",
                                                       need_load_balancer=False,
@@ -274,7 +274,9 @@ class RailsComponent(pulumi.ComponentResource):
             kms_key_id=self.kms_key_id,
             storage_encrypted=bool(self.kms_key_id),
             tags=self.tags,
-            opts=pulumi.ResourceOptions(parent=self, ignore_changes=[ 'database_name', 'master_username'])
+            opts=pulumi.ResourceOptions(parent=self,  # pragma: no cover
+                                        protect=True,
+                                        ignore_changes=['database_name', 'master_username'])
         )
         self.rds_serverless_cluster_instance = aws.rds.ClusterInstance(
             'rds_serverless_cluster_instance',


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-1439)

## Purpose 
When deploying after a snapshot restore, the database name and master username changes. Attempting to correct this requires a recreation of the database cluster.

## Approach 
This ignores these changes so that we don't attempt to recreate the database.

## Testing
Ran locally.
