### PR TITLE
BEL-1474 Add ability to specify log metric filters

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -91,15 +91,17 @@ class ContainerComponent(pulumi.ComponentResource):
         self.log_metric_filter_definitions = kwargs.get('log_metric_filters', [])
         for log_metric_filter in self.log_metric_filter_definitions:
             self.log_metric_filters.append(
-                aws.cloudwatch.LogMetricFilter(log_metric_filter["metric_transformation"]["name"],
-                                               log_group_name=self.logs.name,
-                                               pattern=log_metric_filter["pattern"],
-                                               metric_transformation=aws.cloudwatch.LogMetricFilterMetricTransformationArgs(
-                                                   name=log_metric_filter["metric_transformation"]["name"],
-                                                   value=log_metric_filter["metric_transformation"]["value"],
-                                                   namespace=log_metric_filter["metric_transformation"]["namespace"]
-                                               )
-                                               )
+                aws.cloudwatch.LogMetricFilter(
+                    log_metric_filter["metric_transformation"]["name"],
+                    name=log_metric_filter["metric_transformation"]["name"],
+                    log_group_name=self.logs.name,
+                    pattern=log_metric_filter["pattern"],
+                    metric_transformation=aws.cloudwatch.LogMetricFilterMetricTransformationArgs(
+                        name=log_metric_filter["metric_transformation"]["name"],
+                        value=log_metric_filter["metric_transformation"]["value"],
+                        namespace=log_metric_filter["metric_transformation"]["namespace"]
+                    )
+                )
             )
 
         port_mappings = None

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -32,12 +32,13 @@ class RailsComponent(pulumi.ComponentResource):
         :key execution_cmd: The command for the pre-deployment execution container. Defaults to ["sh", "-c",
                                       "bundle exec rails db:prepare db:migrate db:seed && echo 'Migrations complete'"].
         :key web_entry_point: The entry point for the web container. Defaults to the ENTRYPOINT in the Dockerfile.
-        :key need_worker: Whether to create a worker container. Defaults to True if sidekiq is in the Gemfile.
-        :key worker_entry_point: The entry point for the worker container. Defaults to `["sh", "-c", "bundle exec sidekiq"]`
         :key cpu: The number of CPU units to reserve for the web container. Defaults to 256.
         :key memory: The amount of memory (in MiB) to allow the web container to use. Defaults to 512.
+        :key need_worker: Whether to create a worker container. Defaults to True if sidekiq is in the Gemfile.
+        :key worker_entry_point: The entry point for the worker container. Defaults to `["sh", "-c", "bundle exec sidekiq"]`
         :key worker_cpu: The number of CPU units to reserve for the worker container. Defaults to 256.
         :key worker_memory: The amount of memory (in MiB) to allow the worker container to use. Defaults to 512.
+        :key worker_log_metric_filters: A list of log metric filters to create for the worker container. Defaults to `[]`.
         :key dynamo_tables: A list of DynamoDB tables to create. Defaults to `[]`. Each table is a DynamoComponent.
         :key md5_hash_db_password: Whether to MD5 hash the database password. Defaults to False.
         :key storage: Whether to create an S3 bucket for the Rails application. Defaults to False.
@@ -68,6 +69,7 @@ class RailsComponent(pulumi.ComponentResource):
         self.rds_serverless_cluster_instance = None
         self.rds_serverless_cluster = None
         self.kwargs = kwargs
+        self.worker_log_metric_filters = self.kwargs.get('worker_log_metric_filters', [])
         self.snapshot_identifier = self.kwargs.get('snapshot_identifier', None)
         self.kms_key_id = self.kwargs.get('kms_key_id', None)
         self.dynamo_tables = self.kwargs.get('dynamo_tables', [])
@@ -217,7 +219,7 @@ class RailsComponent(pulumi.ComponentResource):
             self.need_worker = sidekiq_present()
 
         if self.need_worker:
-            self.setup_worker()  # execution)
+            self.setup_worker()
 
         if self.kwargs.get('storage', False):
             self.setup_storage()
@@ -232,12 +234,14 @@ class RailsComponent(pulumi.ComponentResource):
         self.kwargs['ecs_cluster_arn'] = self.ecs_cluster.arn
         self.kwargs['need_load_balancer'] = False
         self.kwargs['secrets'] = self.secret.get_secrets()  # pragma: no cover
+        self.kwargs['log_metric_filters'] = self.worker_log_metric_filters
         self.worker_container = ContainerComponent("worker",
                                                    pulumi.ResourceOptions(parent=self,
                                                                           depends_on=[self.execution]
                                                                           ),
                                                    **self.kwargs
                                                    )
+        self.kwargs['log_metric_filters'] = []
 
     def secrets(self):
         self.secret = SecretsComponent("secrets",

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -35,7 +35,7 @@ class RailsComponent(pulumi.ComponentResource):
         :key cpu: The number of CPU units to reserve for the web container. Defaults to 256.
         :key memory: The amount of memory (in MiB) to allow the web container to use. Defaults to 512.
         :key need_worker: Whether to create a worker container. Defaults to True if sidekiq is in the Gemfile.
-        :key worker_entry_point: The entry point for the worker container. Defaults to `["sh", "-c", "bundle exec sidekiq"]`
+        :key worker_entry_point: The entry point for the worker container. Defaults to `["sh", "-c", "bundle exec sidekiq"]`. Requires need_worker to be True.
         :key worker_cpu: The number of CPU units to reserve for the worker container. Defaults to 256.
         :key worker_memory: The amount of memory (in MiB) to allow the worker container to use. Defaults to 512.
         :key worker_log_metric_filters: A list of log metric filters to create for the worker container. Defaults to `[]`.

--- a/deployment/src/tests/test_container.py
+++ b/deployment/src/tests/test_container.py
@@ -504,3 +504,104 @@ def describe_a_pulumi_containerized_app():
         @pulumi.runtime.test
         def it_uses_existing_cluster(sut, existing_cluster_arn):
             return assert_output_equals(sut.fargate_service.cluster, existing_cluster_arn)
+
+    def describe_logs():
+        @pulumi.runtime.test
+        def it_creates_a_log_group(sut, stack, app_name):
+            return assert_output_equals(sut.logs.name, f"/aws/ecs/{app_name}-{stack}")
+
+        @pulumi.runtime.test
+        def it_sets_retention(sut):
+            return assert_output_equals(sut.logs.retention_in_days, 14)
+
+        @pulumi.runtime.test
+        def it_has_no_filters(sut):
+            return sut.log_metric_filters == []
+
+        def describe_with_job_filters():
+
+            @pytest.fixture
+            def waiting_workers_pattern():
+                return "[LETTER, DATE, LEVEL, SEP, N, I, HAVE, WAITING_JOBS, JOBS, FOR, WAITING_WORKERS, " \
+                       "WAITING=waiting, WORKERS=workers]"
+
+            @pytest.fixture
+            def waiting_jobs_pattern():
+                return "[LETTER, DATE, LEVEL, SEP, N, I, HAVE, WAITING_JOBS, JOBS, FOR, WAITING_WORKERS, " \
+                       "WAITING=waiting, WORKERS=workers]"
+
+            @pytest.fixture
+            def waiting_workers_metric_value():
+                return "$WAITING_WORKERS"
+
+            @pytest.fixture
+            def waiting_jobs_metric_value():
+                return "$WAITING_JOBS"
+
+            @pytest.fixture
+            def log_metric_filters(waiting_workers_pattern, waiting_jobs_pattern,
+                                   waiting_workers_metric_value, waiting_jobs_metric_value):
+                return [
+                    {
+                        "pattern": waiting_workers_pattern,
+                        "metric_transformation": {
+                            "name": "waiting_workers",
+                            "namespace": "Jobs",
+                            "value": waiting_workers_metric_value,
+                        }
+                    },
+                    {
+                        "pattern": waiting_jobs_pattern,
+                        "metric_transformation": {
+                            "name": "waiting_jobs",
+                            "namespace": "Jobs",
+                            "value": waiting_jobs_metric_value,
+                        }
+                    }
+                ]
+
+            @pytest.fixture
+            def component_kwargs(component_kwargs, log_metric_filters):
+                component_kwargs["log_metric_filters"] = log_metric_filters
+                return component_kwargs
+
+            @pulumi.runtime.test
+            def it_creates_metric_filters(sut):
+                assert sut.log_metric_filters
+
+            @pulumi.runtime.test
+            def it_sets_the_workers_pattern(sut, waiting_workers_pattern):
+                return assert_output_equals(sut.log_metric_filters[0].pattern, waiting_workers_pattern)
+
+            @pulumi.runtime.test
+            def it_sets_the_workers_metric_name(sut):
+                return assert_output_equals(sut.log_metric_filters[0].metric_transformation.name,
+                                            "waiting_workers")
+
+            @pulumi.runtime.test
+            def it_sets_the_workers_values(sut, waiting_workers_metric_value):
+                return assert_output_equals(sut.log_metric_filters[0].metric_transformation.value,
+                                            waiting_workers_metric_value)
+
+            @pulumi.runtime.test
+            def it_sets_the_workers_namespace(sut):
+                return assert_output_equals(sut.log_metric_filters[0].metric_transformation.namespace,
+                                            "Jobs")
+            @pulumi.runtime.test
+            def it_sets_the_jobs_pattern(sut, waiting_jobs_pattern):
+                return assert_output_equals(sut.log_metric_filters[1].pattern, waiting_jobs_pattern)
+
+            @pulumi.runtime.test
+            def it_sets_the_jobs_metric_name(sut):
+                return assert_output_equals(sut.log_metric_filters[1].metric_transformation.name,
+                                            "waiting_jobs")
+
+            @pulumi.runtime.test
+            def it_sets_the_jobs_values(sut, waiting_jobs_metric_value):
+                return assert_output_equals(sut.log_metric_filters[1].metric_transformation.value,
+                                            waiting_jobs_metric_value)
+
+            @pulumi.runtime.test
+            def it_sets_the_jobs_namespace(sut):
+                return assert_output_equals(sut.log_metric_filters[1].metric_transformation.namespace,
+                                            "Jobs")

--- a/deployment/src/tests/test_rails.py
+++ b/deployment/src/tests/test_rails.py
@@ -639,6 +639,35 @@ def describe_a_pulumi_rails_app():
             def it_uses_cluster_from_web_container(sut):
                 assert sut.worker_container.ecs_cluster_arn == sut.web_container.ecs_cluster_arn
 
+            def describe_worker_log_metric_filters():
+                @pytest.fixture
+                def worker_log_metric_filters(faker):
+                    return [
+                    {
+                        "pattern": "BLAH DAH",
+                        "metric_transformation": {
+                            "name": "waiting_workers",
+                            "namespace": "Jobs",
+                            "value": "$BLAH",
+                        }
+                    }
+                ]
+
+                @pytest.fixture
+                def component_kwargs(component_kwargs, worker_log_metric_filters):
+                    component_kwargs['worker_log_metric_filters'] = worker_log_metric_filters
+                    return component_kwargs
+
+                @pulumi.runtime.test
+                def it_passes_worker_log_metric_filter_pattern_to_worker_container(sut, worker_log_metric_filters):
+                    return assert_output_equals(sut.worker_container.log_metric_filters[0].pattern,
+                                                "BLAH DAH")
+
+                @pulumi.runtime.test
+                def it_passes_worker_log_metric_filter_value_to_worker_container(sut, worker_log_metric_filters):
+                    return assert_output_equals(sut.worker_container.log_metric_filters[0].metric_transformation.value,
+                                                "$BLAH")
+
     @pulumi.runtime.test
     def it_allows_container_to_talk_to_rds(sut, ecs_security_groups):
         assert sut.firewall_rule
@@ -816,3 +845,4 @@ def describe_a_pulumi_rails_app():
         @pulumi.runtime.test
         def it_sends_the_bucket_name_to_the_ecs_environment(sut):
             return assert_outputs_equal(sut.env_vars["S3_BUCKET_NAME"], sut.storage.bucket.bucket)
+


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-1474)

## Purpose 
In order to evaluate the current state of jobs/workers, we need a way to parse CloudWatch logs.

## Approach 
Use log metric filters to parse the logs.

## Testing
Added filters to frozen-desserts.