### PR TITLE
BEL-1382 Enable auto scaling upwards for web

### DIFF
--- a/deployment/pyproject.toml
+++ b/deployment/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "strongmind_deployment"
-version = "1.1.17"
+version = "1.1.18"
 
 authors = [
   { name="Belding", email="teambelding@strongmind.com" },

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -206,14 +206,13 @@ class RailsComponent(pulumi.ComponentResource):
 
         self.kwargs['secrets'] = self.secret.get_secrets()  # pragma: no cover
         self.kwargs['entry_point'] = web_entry_point
-        self.kwargs['autoscaling'] = True
         self.web_container = ContainerComponent("container",
                                                 pulumi.ResourceOptions(parent=self,
                                                                        depends_on=[self.execution]
                                                                        ),
+                                                autoscaling=True,
                                                 **self.kwargs
                                                 )
-        self.kwargs['autoscaling'] = False
         self.need_worker = self.kwargs.get('need_worker', None)
         if self.need_worker is None:  # pragma: no cover
             # If we don't know if we need a worker, check for sidekiq in the Gemfile

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -206,13 +206,14 @@ class RailsComponent(pulumi.ComponentResource):
 
         self.kwargs['secrets'] = self.secret.get_secrets()  # pragma: no cover
         self.kwargs['entry_point'] = web_entry_point
+        self.kwargs['autoscaling'] = True
         self.web_container = ContainerComponent("container",
                                                 pulumi.ResourceOptions(parent=self,
                                                                        depends_on=[self.execution]
                                                                        ),
                                                 **self.kwargs
                                                 )
-
+        self.kwargs['autoscaling'] = False
         self.need_worker = self.kwargs.get('need_worker', None)
         if self.need_worker is None:  # pragma: no cover
             # If we don't know if we need a worker, check for sidekiq in the Gemfile

--- a/deployment/src/tests/test_container.py
+++ b/deployment/src/tests/test_container.py
@@ -499,6 +499,7 @@ def describe_a_pulumi_containerized_app():
         def component_kwargs(component_kwargs):
             component_kwargs["autoscaling"] = True
             return component_kwargs
+
         @pulumi.runtime.test
         def it_has_an_autoscaling_target(sut):
             assert sut.autoscaling_target
@@ -523,6 +524,62 @@ def describe_a_pulumi_containerized_app():
         def it_uses_the_clusters_resource_id(sut):
             resource_id = f"service/{sut.project_stack}/{sut.project_stack}"
             return assert_output_equals(sut.autoscaling_target.resource_id, resource_id)
+
+        def describe_autoscaling_policy():
+            @pulumi.runtime.test
+            def it_exists(sut):
+                assert sut.autoscaling_policy
+
+            @pulumi.runtime.test
+            def it_has_a_step_scaling_policy_type(sut):
+                return assert_output_equals(sut.autoscaling_policy.policy_type, "StepScaling")
+
+            @pulumi.runtime.test
+            def it_uses_the_clusters_resource_id(sut):
+                resource_id = f"service/{sut.project_stack}/{sut.project_stack}"
+                return assert_output_equals(sut.autoscaling_policy.resource_id, resource_id)
+
+            @pulumi.runtime.test
+            def it_has_a_default_scalable_dimension_of_desired_count(sut):
+                return assert_output_equals(sut.autoscaling_policy.scalable_dimension, "ecs:service:DesiredCount")
+
+            @pulumi.runtime.test
+            def it_has_a_default_service_namespace(sut):
+                return assert_output_equals(sut.autoscaling_policy.service_namespace, "ecs")
+
+            @pulumi.runtime.test
+            def it_has_a_step_scaling_policy_configuration(sut):
+                assert sut.autoscaling_policy.step_scaling_policy_configuration
+
+            @pulumi.runtime.test
+            def it_has_a_default_cooldown(sut):
+                return assert_output_equals(sut.autoscaling_policy.step_scaling_policy_configuration.cooldown, 60)
+
+            @pulumi.runtime.test
+            def it_changes_capacity(sut):
+                return assert_output_equals(sut.autoscaling_policy.step_scaling_policy_configuration.adjustment_type, "ChangeInCapacity")
+
+            @pulumi.runtime.test
+            def it_has_a_default_maximum_metric_aggregation_type(sut):
+                return assert_output_equals(sut.autoscaling_policy.step_scaling_policy_configuration.metric_aggregation_type, "Maximum")
+
+            @pulumi.runtime.test
+            def it_has_steps(sut):
+                assert sut.autoscaling_policy.step_scaling_policy_configuration.step_adjustments
+
+            def describe_first_step():
+                @pytest.fixture
+                def step(sut):
+                    return sut.autoscaling_policy.step_scaling_policy_configuration.step_adjustments[0]
+
+                @pulumi.runtime.test
+                def it_has_a_default_metric_interval_upper_bound(step):
+                    return assert_output_equals(step.metric_interval_upper_bound, "65")
+
+                @pulumi.runtime.test
+                def it_scales_up_by_one_instance(step):
+                    return assert_output_equals(step.scaling_adjustment, 1)
+
 
     def describe_with_existing_cluster():
         @pytest.fixture

--- a/deployment/src/tests/test_container.py
+++ b/deployment/src/tests/test_container.py
@@ -181,7 +181,12 @@ def describe_a_pulumi_containerized_app():
 
         @pulumi.runtime.test
         def its_execution_role_has_an_arn(sut):
-            return assert_output_equals(sut.execution_role.arn, "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy")
+            return assert_output_equals(sut.execution_role.arn,
+                                        "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy")
+
+        @pulumi.runtime.test
+        def it_has_no_autoscaling_target(sut):
+            assert not sut.autoscaling_target
 
         def describe_with_no_load_balancer():
             @pytest.fixture
@@ -201,7 +206,6 @@ def describe_a_pulumi_containerized_app():
             @pulumi.runtime.test
             def it_has_no_grace_period(sut):
                 return assert_output_equals(sut.fargate_service.health_check_grace_period_seconds, None)
-
 
         def describe_load_balancer():
             @pulumi.runtime.test
@@ -352,7 +356,8 @@ def describe_a_pulumi_containerized_app():
                                          sut.ecs_cluster.arn).apply(check_cluster)
 
             @pulumi.runtime.test
-            def it_has_task_definition(sut, container_port, cpu, memory, entry_point, command, stack, app_name, secrets):
+            def it_has_task_definition(sut, container_port, cpu, memory, entry_point, command, stack, app_name,
+                                       secrets):
                 def check_task_definition(args):
                     task_definition_dict = args[0]
                     container = task_definition_dict["container"]
@@ -407,6 +412,7 @@ def describe_a_pulumi_containerized_app():
             @pulumi.runtime.test
             def it_sets_the_target_group_health_check_path(sut, custom_health_check_path):
                 return assert_output_equals(sut.target_group.health_check.path, custom_health_check_path)
+
     def describe_dns():
         @pulumi.runtime.test
         def it_has_cname_record(sut):
@@ -488,6 +494,35 @@ def describe_a_pulumi_containerized_app():
             return assert_outputs_equal(sut.cert_validation_cert.validation_record_fqdns,
                                         [sut.cert_validation_record.hostname])
 
+    def describe_autoscaling():
+        @pytest.fixture
+        def component_kwargs(component_kwargs):
+            component_kwargs["autoscaling"] = True
+            return component_kwargs
+        @pulumi.runtime.test
+        def it_has_an_autoscaling_target(sut):
+            assert sut.autoscaling_target
+
+        @pulumi.runtime.test
+        def it_has_a_default_max_capacity(sut):
+            return assert_output_equals(sut.autoscaling_target.max_capacity, 3)
+
+        @pulumi.runtime.test
+        def it_has_a_default_min_capacity(sut):
+            return assert_output_equals(sut.autoscaling_target.min_capacity, 1)
+
+        @pulumi.runtime.test
+        def it_has_a_default_scalable_dimension_of_desired_count(sut):
+            return assert_output_equals(sut.autoscaling_target.scalable_dimension, "ecs:service:DesiredCount")
+
+        @pulumi.runtime.test
+        def it_uses_the_default_service_namespace_of_ecs(sut):
+            return assert_output_equals(sut.autoscaling_target.service_namespace, "ecs")
+
+        @pulumi.runtime.test
+        def it_uses_the_clusters_resource_id(sut):
+            resource_id = f"service/{sut.project_stack}/{sut.project_stack}"
+            return assert_output_equals(sut.autoscaling_target.resource_id, resource_id)
 
     def describe_with_existing_cluster():
         @pytest.fixture

--- a/deployment/src/tests/test_rails.py
+++ b/deployment/src/tests/test_rails.py
@@ -219,6 +219,10 @@ def describe_a_pulumi_rails_app():
     def it_has_no_dynamo_tables(sut):
         assert sut.dynamo_tables == []
 
+    @pulumi.runtime.test
+    def it_asks_the_web_container_to_automatically_scale(sut):
+        assert sut.web_container.autoscaling
+
     def describe_secretmanager_secret():
         @pulumi.runtime.test
         def it_has_a_secret(sut):


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-1382)

## Purpose 
So that we can continue serving traffic under load, when the web servers are at high CPU utilisation, scale up the number of containers running.

## Approach 
Use pulumi to set up auto scaling targets, policies and alarms.

## Testing
Tested in canvas stage, will test with frozen desserts.