### PR TITLE
BEL-1382 Dimensions for autoscaling alarm

### DIFF
--- a/deployment/pyproject.toml
+++ b/deployment/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "strongmind_deployment"
-version = "1.1.18"
+version = "1.1.19"
 
 authors = [
   { name="Belding", email="teambelding@strongmind.com" },

--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -229,6 +229,7 @@ class ContainerComponent(pulumi.ComponentResource):
         )
         self.autoscaling_policy = aws.appautoscaling.Policy(
             "autoscaling_policy",
+            name=f"{self.project_stack} Autoscaling Policy",
             policy_type="StepScaling",
             resource_id=self.autoscaling_target.resource_id,
             scalable_dimension=self.autoscaling_target.scalable_dimension,
@@ -252,9 +253,15 @@ class ContainerComponent(pulumi.ComponentResource):
         )
         self.autoscaling_alarm = aws.cloudwatch.MetricAlarm(
             "autoscaling_alarm",
+            name=f"{self.project_stack} Auto Scaling Alarm",
             comparison_operator="GreaterThanOrEqualToThreshold",
             evaluation_periods=1,
             metric_name="CPUUtilization",
+            unit="Percent",
+            dimensions={
+                "ClusterName": self.project_stack,
+                "ServiceName": self.project_stack
+            },
             namespace="AWS/ECS",
             period=60,
             statistic="Maximum",

--- a/deployment/src/tests/test_container.py
+++ b/deployment/src/tests/test_container.py
@@ -543,6 +543,18 @@ def describe_a_pulumi_containerized_app():
                 return assert_output_equals(sut.autoscaling_alarm.metric_name, "CPUUtilization")
 
             @pulumi.runtime.test
+            def it_checks_the_unit_as_a_percentage(sut):
+                return assert_output_equals(sut.autoscaling_alarm.unit, "Percent")
+
+            @pulumi.runtime.test
+            def it_pulls_the_metric_data_from_the_cluster(sut):
+                return assert_output_equals(sut.autoscaling_alarm.dimensions["ClusterName"], sut.project_stack)
+
+            @pulumi.runtime.test
+            def it_pulls_the_metric_data_from_the_service(sut):
+                return assert_output_equals(sut.autoscaling_alarm.dimensions["ServiceName"], sut.project_stack)
+
+            @pulumi.runtime.test
             def it_belongs_to_the_ECS_namespace(sut):
                 return assert_output_equals(sut.autoscaling_alarm.namespace, "AWS/ECS")
 


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-1382)

## Purpose 
Include dimensions for the alarm so that they are tied to the cluster for the use of autoscaling.

## Approach 
Added in the autoscaling method. Unit tested.

## Testing
Unit tested and tested against canvas-stage and frozen-desserts.
