### PR TITLE
S3 storage options for deployment

### DIFF
--- a/deployment/pyproject.toml
+++ b/deployment/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "strongmind_deployment"
-version = "1.1.20"
+version = "1.1.21"
 
 authors = [
   { name="Belding", email="teambelding@strongmind.com" },

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -42,6 +42,7 @@ class RailsComponent(pulumi.ComponentResource):
         :key dynamo_tables: A list of DynamoDB tables to create. Defaults to `[]`. Each table is a DynamoComponent.
         :key md5_hash_db_password: Whether to MD5 hash the database password. Defaults to False.
         :key storage: Whether to create an S3 bucket for the Rails application. Defaults to False.
+        :key storage_private: Sets the bucket to public when false. Defaults to True.
         :key custom_health_check_path: The path to use for the health check. Defaults to `/up`.
         :key snapshot_identifier: The snapshot identifier to use for the RDS cluster. Defaults to None.
         :key kms_key_id: The KMS key ID to use for the RDS cluster. Defaults to None.
@@ -56,6 +57,7 @@ class RailsComponent(pulumi.ComponentResource):
         self.queue_redis = None
         self.cache_redis = None
         self.storage = None
+        self.storage_private = None
         self.need_worker = None
         self.cname_record = None
         self.firewall_rule = None

--- a/deployment/src/strongmind_deployment/storage.py
+++ b/deployment/src/strongmind_deployment/storage.py
@@ -29,7 +29,11 @@ class StorageComponent(pulumi.ComponentResource):
                                                                         ))
         self.bucket_public_access_block = aws.s3.BucketPublicAccessBlock("bucket_public_access_block",
                                                                          bucket=self.bucket.id,
-                                                                         block_public_acls= kwargs.get('storage_private', True))
+                                                                         block_public_acls=kwargs.get('storage_private', True),
+                                                                         block_public_policy=kwargs.get('storage_private', True),
+                                                                         ignore_public_acls=kwargs.get('storage_private', True),
+                                                                         restrict_public_buckets=kwargs.get('storage_private', True)
+                                                                         )
 
         acl_opts = pulumi.ResourceOptions(
             depends_on=[self.bucket_ownership_controls, self.bucket_public_access_block])  # pragma: no cover

--- a/deployment/src/strongmind_deployment/storage.py
+++ b/deployment/src/strongmind_deployment/storage.py
@@ -29,7 +29,7 @@ class StorageComponent(pulumi.ComponentResource):
                                                                         ))
         self.bucket_public_access_block = aws.s3.BucketPublicAccessBlock("bucket_public_access_block",
                                                                          bucket=self.bucket.id,
-                                                                         block_public_acls=False)
+                                                                         block_public_acls= kwargs.get('storage_private', True))
 
         acl_opts = pulumi.ResourceOptions(
             depends_on=[self.bucket_ownership_controls, self.bucket_public_access_block])  # pragma: no cover

--- a/deployment/src/tests/test_storage.py
+++ b/deployment/src/tests/test_storage.py
@@ -87,8 +87,19 @@ def describe_a_pulumi_storage_component():
             return assert_outputs_equal(sut.bucket_public_access_block.bucket, sut.bucket.id)
 
         @pulumi.runtime.test
-        def it_allows_public_acls(sut):
-            return assert_output_equals(sut.bucket_public_access_block.block_public_acls, False)
+        def it_blocks_public_acls(sut):
+            return assert_output_equals(sut.bucket_public_access_block.block_public_acls, True)
+        
+        def describe_when_storage_is_set_to_public():
+            @pytest.fixture
+            def component_arguments():
+                return {
+                    "storage_private": False
+                }
+
+            @pulumi.runtime.test
+            def it_blocks_public_access(sut):
+                return assert_output_equals(sut.bucket_public_access_block.block_public_acls, False)
 
     def describe_acls():
         def it_has_acls(sut):


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/DEVOPS-10396)

## Purpose 
To default s3 buckets to private and allow override to set the bucket to public

## Approach 
Set storage key default to True to make the bucket private
Added new kwarg to allow the bucket to be public
Added test for new kwarg in storage

## Testing
Ran tests and they passed
