### PR TITLE
BEL-1378 Scale in for web

### DIFF
--- a/deployment/pyproject.toml
+++ b/deployment/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "strongmind_deployment"
-version = "1.1.21"
+version = "1.1.22"
 
 authors = [
   { name="Belding", email="teambelding@strongmind.com" },

--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -284,8 +284,7 @@ class ContainerComponent(pulumi.ComponentResource):
                 metric_aggregation_type="Maximum",
                 step_adjustments=[
                     aws.appautoscaling.PolicyStepScalingPolicyConfigurationStepAdjustmentArgs(
-                        metric_interval_upper_bound="10",
-                        metric_interval_lower_bound="0",
+                        metric_interval_upper_bound="0",
                         scaling_adjustment=1,
                     )
                 ],

--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -305,7 +305,7 @@ class ContainerComponent(pulumi.ComponentResource):
             period=60,
             statistic="Average",
             threshold=50,
-            alarm_actions=[self.autoscaling_out_policy.arn]
+            alarm_actions=[self.autoscaling_in_policy.arn]
         )
 
     def setup_load_balancer(self, kwargs, project, project_stack):

--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -34,7 +34,7 @@ class ContainerComponent(pulumi.ComponentResource):
         """
         super().__init__('strongmind:global_build:commons:container', name, None, opts)
 
-        self.autoscaling_alarm = None
+        self.autoscaling_out_alarm = None
         self.log_metric_filters = []
         self.target_group = None
         self.load_balancer_listener_redirect_http_to_https = None
@@ -57,7 +57,7 @@ class ContainerComponent(pulumi.ComponentResource):
         self.kwargs = kwargs
         self.env_name = os.environ.get('ENVIRONMENT_NAME', 'stage')
         self.autoscaling_target = None
-        self.autoscaling_policy = None
+        self.autoscaling_out_policy = None
         self.max_capacity = kwargs.get('max_number_of_instances', 1)
 
         stack = pulumi.get_stack()
@@ -230,7 +230,7 @@ class ContainerComponent(pulumi.ComponentResource):
             scalable_dimension="ecs:service:DesiredCount",
             service_namespace="ecs",
         )
-        self.autoscaling_policy = aws.appautoscaling.Policy(
+        self.autoscaling_out_policy = aws.appautoscaling.Policy(
             "autoscaling_policy",
             name=f"{self.project_stack} Autoscaling Policy",
             policy_type="StepScaling",
@@ -254,7 +254,7 @@ class ContainerComponent(pulumi.ComponentResource):
                 ],
             )
         )
-        self.autoscaling_alarm = aws.cloudwatch.MetricAlarm(
+        self.autoscaling_out_alarm = aws.cloudwatch.MetricAlarm(
             "autoscaling_alarm",
             name=f"{self.project_stack} Auto Scaling Alarm",
             comparison_operator="GreaterThanOrEqualToThreshold",
@@ -269,7 +269,7 @@ class ContainerComponent(pulumi.ComponentResource):
             period=60,
             statistic="Average",
             threshold=65,
-            alarm_actions=[self.autoscaling_policy.arn]
+            alarm_actions=[self.autoscaling_out_policy.arn]
         )
 
     def setup_load_balancer(self, kwargs, project, project_stack):

--- a/deployment/src/tests/mocks.py
+++ b/deployment/src/tests/mocks.py
@@ -89,6 +89,11 @@ def get_pulumi_mocks(faker, fake_password=None, secret_string="{}"):
                     **args.inputs,
                     "arn": f"arn:aws:secretsmanager:us-west-2:123456789012:secret/{faker.word()}",
                 }
+            if args.typ == "aws:appautoscaling/policy:Policy":
+                outputs = {
+                    **args.inputs,
+                    "arn": f"arn:aws:appautoscaling:us-west-2:123456789012:policy/{faker.word()}",
+                }
             if args.typ == "aws:secretsmanager/secretVersion:SecretVersion":
                 outputs = {
                     **args.inputs,

--- a/deployment/src/tests/test_container.py
+++ b/deployment/src/tests/test_container.py
@@ -2,12 +2,13 @@ import os
 
 import pulumi.runtime
 import pytest
+from pytest_describe import behaves_like
 
 from tests.mocks import get_pulumi_mocks
 from tests.shared import assert_output_equals, assert_outputs_equal
 
 
-def describe_a_pulumi_containerized_app():
+def a_pulumi_containerized_app():
     @pytest.fixture
     def app_name(faker):
         return faker.word()
@@ -158,6 +159,9 @@ def describe_a_pulumi_containerized_app():
     def it_exists(sut):
         assert sut
 
+
+@behaves_like(a_pulumi_containerized_app)
+def describe_container():
     def describe_a_container_component():
         @pulumi.runtime.test
         def it_creates_an_ecs_cluster(sut):
@@ -494,174 +498,6 @@ def describe_a_pulumi_containerized_app():
             return assert_outputs_equal(sut.cert_validation_cert.validation_record_fqdns,
                                         [sut.cert_validation_record.hostname])
 
-    def describe_autoscaling():
-        @pytest.fixture
-        def component_kwargs(component_kwargs):
-            component_kwargs["autoscaling"] = True
-            return component_kwargs
-
-        @pulumi.runtime.test
-        def it_has_an_autoscaling_target(sut):
-            assert sut.autoscaling_target
-
-        @pulumi.runtime.test
-        def it_has_a_default_max_capacity(sut):
-            return assert_output_equals(sut.autoscaling_target.max_capacity, 1)
-
-        def describe_autoscaling_overrides():
-            @pytest.fixture
-            def component_kwargs(component_kwargs):
-                component_kwargs["max_number_of_instances"] = 10
-                return component_kwargs
-
-            @pulumi.runtime.test
-            def it_has_a_configurable_max_capacity(sut):
-                return assert_output_equals(sut.autoscaling_target.max_capacity, 10)
-
-        @pulumi.runtime.test
-        def it_has_a_default_min_capacity(sut):
-            return assert_output_equals(sut.autoscaling_target.min_capacity, 1)
-
-        @pulumi.runtime.test
-        def it_has_a_default_scalable_dimension_of_desired_count(sut):
-            return assert_output_equals(sut.autoscaling_target.scalable_dimension, "ecs:service:DesiredCount")
-
-        @pulumi.runtime.test
-        def it_uses_the_default_service_namespace_of_ecs(sut):
-            return assert_output_equals(sut.autoscaling_target.service_namespace, "ecs")
-
-        @pulumi.runtime.test
-        def it_uses_the_clusters_resource_id(sut):
-            resource_id = f"service/{sut.project_stack}/{sut.project_stack}"
-            return assert_output_equals(sut.autoscaling_target.resource_id, resource_id)
-
-        def describe_autoscaling_out_alarm():
-            @pulumi.runtime.test
-            def it_exists(sut):
-                assert sut.autoscaling_out_alarm
-
-            @pulumi.runtime.test
-            def it_triggers_when_greater_than_or_equal_to_threshold(sut):
-                return assert_output_equals(sut.autoscaling_out_alarm.comparison_operator, "GreaterThanOrEqualToThreshold")
-
-            @pulumi.runtime.test
-            def it_evaluates_for_one_period(sut):
-                return assert_output_equals(sut.autoscaling_out_alarm.evaluation_periods, 1)
-
-            @pulumi.runtime.test
-            def it_triggers_based_on_CPU_utilization(sut):
-                return assert_output_equals(sut.autoscaling_out_alarm.metric_name, "CPUUtilization")
-
-            @pulumi.runtime.test
-            def it_checks_the_unit_as_a_percentage(sut):
-                return assert_output_equals(sut.autoscaling_out_alarm.unit, "Percent")
-
-            @pulumi.runtime.test
-            def it_pulls_the_metric_data_from_the_cluster(sut):
-                return assert_output_equals(sut.autoscaling_out_alarm.dimensions["ClusterName"], sut.project_stack)
-
-            @pulumi.runtime.test
-            def it_pulls_the_metric_data_from_the_service(sut):
-                return assert_output_equals(sut.autoscaling_out_alarm.dimensions["ServiceName"], sut.project_stack)
-
-            @pulumi.runtime.test
-            def it_belongs_to_the_ECS_namespace(sut):
-                return assert_output_equals(sut.autoscaling_out_alarm.namespace, "AWS/ECS")
-
-            @pulumi.runtime.test
-            def it_runs_every_minute(sut):
-                return assert_output_equals(sut.autoscaling_out_alarm.period, 60)
-
-            @pulumi.runtime.test
-            def it_uses_average_statistic_by_default(sut):
-                return assert_output_equals(sut.autoscaling_out_alarm.statistic, "Average")
-
-            @pulumi.runtime.test
-            def it_triggers_when_CPU_utilization_is_over_65(sut):
-                return assert_output_equals(sut.autoscaling_out_alarm.threshold, 65)
-
-            @pulumi.runtime.test
-            def it_triggers_the_autoscaling_policy(sut):
-                return assert_outputs_equal(sut.autoscaling_out_alarm.alarm_actions, [sut.autoscaling_out_policy.arn])
-
-
-        def describe_autoscaling_policy():
-            @pulumi.runtime.test
-            def it_exists(sut):
-                assert sut.autoscaling_out_policy
-
-            @pulumi.runtime.test
-            def it_has_a_step_scaling_policy_type(sut):
-                return assert_output_equals(sut.autoscaling_out_policy.policy_type, "StepScaling")
-
-            @pulumi.runtime.test
-            def it_uses_the_clusters_resource_id(sut):
-                resource_id = f"service/{sut.project_stack}/{sut.project_stack}"
-                return assert_output_equals(sut.autoscaling_out_policy.resource_id, resource_id)
-
-            @pulumi.runtime.test
-            def it_has_a_default_scalable_dimension_of_desired_count(sut):
-                return assert_output_equals(sut.autoscaling_out_policy.scalable_dimension, "ecs:service:DesiredCount")
-
-            @pulumi.runtime.test
-            def it_has_a_default_service_namespace(sut):
-                return assert_output_equals(sut.autoscaling_out_policy.service_namespace, "ecs")
-
-            @pulumi.runtime.test
-            def it_has_a_step_scaling_policy_configuration(sut):
-                assert sut.autoscaling_out_policy.step_scaling_policy_configuration
-
-            @pulumi.runtime.test
-            def it_has_a_default_cooldown(sut):
-                return assert_output_equals(sut.autoscaling_out_policy.step_scaling_policy_configuration.cooldown, 60)
-
-            @pulumi.runtime.test
-            def it_changes_capacity(sut):
-                return assert_output_equals(sut.autoscaling_out_policy.step_scaling_policy_configuration.adjustment_type, "ChangeInCapacity")
-
-            @pulumi.runtime.test
-            def it_has_a_default_maximum_metric_aggregation_type(sut):
-                return assert_output_equals(sut.autoscaling_out_policy.step_scaling_policy_configuration.metric_aggregation_type, "Maximum")
-
-            @pulumi.runtime.test
-            def it_has_steps(sut):
-                assert sut.autoscaling_out_policy.step_scaling_policy_configuration.step_adjustments
-
-            def describe_first_step():
-                @pytest.fixture
-                def step(sut):
-                    return sut.autoscaling_out_policy.step_scaling_policy_configuration.step_adjustments[0]
-
-                @pulumi.runtime.test
-                def it_triggers_when_it_exceeds_the_alarm_threshold(step):
-                    return assert_output_equals(step.metric_interval_lower_bound, "0")
-
-                @pulumi.runtime.test
-                def it_triggers_when_it_exceeds_the_alarm_threshold_by_up_to_ten(step):
-                    return assert_output_equals(step.metric_interval_upper_bound, "10")
-
-
-                @pulumi.runtime.test
-                def it_scales_up_by_one_instance(step):
-                    return assert_output_equals(step.scaling_adjustment, 1)
-
-            def describe_second_step():
-                @pytest.fixture
-                def step(sut):
-                    return sut.autoscaling_out_policy.step_scaling_policy_configuration.step_adjustments[1]
-
-                @pulumi.runtime.test
-                def it_triggers_when_it_exceeds_the_alarm_threshold_by_more_than_ten(step):
-                    return assert_output_equals(step.metric_interval_lower_bound, "10")
-
-                @pulumi.runtime.test
-                def it_triggers_at_all_higher_values_than_ten(step):
-                    return assert_output_equals(step.metric_interval_upper_bound, None)
-
-                @pulumi.runtime.test
-                def it_scales_up_by_three_instances(step):
-                    return assert_output_equals(step.scaling_adjustment, 3)
-
     def describe_with_existing_cluster():
         @pytest.fixture
         def existing_cluster_arn(faker):
@@ -692,7 +528,6 @@ def describe_a_pulumi_containerized_app():
             return sut.log_metric_filters == []
 
         def describe_with_job_filters():
-
             @pytest.fixture
             def waiting_workers_pattern():
                 return "[LETTER, DATE, LEVEL, SEP, N, I, HAVE, WAITING_JOBS, JOBS, FOR, WAITING_WORKERS, " \
@@ -760,6 +595,7 @@ def describe_a_pulumi_containerized_app():
             def it_sets_the_workers_namespace(sut):
                 return assert_output_equals(sut.log_metric_filters[0].metric_transformation.namespace,
                                             "Jobs")
+
             @pulumi.runtime.test
             def it_sets_the_jobs_pattern(sut, waiting_jobs_pattern):
                 return assert_output_equals(sut.log_metric_filters[1].pattern, waiting_jobs_pattern)

--- a/deployment/src/tests/test_container.py
+++ b/deployment/src/tests/test_container.py
@@ -535,101 +535,102 @@ def describe_a_pulumi_containerized_app():
             resource_id = f"service/{sut.project_stack}/{sut.project_stack}"
             return assert_output_equals(sut.autoscaling_target.resource_id, resource_id)
 
-        def describe_autoscaling_alarm():
+        def describe_autoscaling_out_alarm():
             @pulumi.runtime.test
             def it_exists(sut):
-                assert sut.autoscaling_alarm
+                assert sut.autoscaling_out_alarm
 
             @pulumi.runtime.test
             def it_triggers_when_greater_than_or_equal_to_threshold(sut):
-                return assert_output_equals(sut.autoscaling_alarm.comparison_operator, "GreaterThanOrEqualToThreshold")
+                return assert_output_equals(sut.autoscaling_out_alarm.comparison_operator, "GreaterThanOrEqualToThreshold")
 
             @pulumi.runtime.test
             def it_evaluates_for_one_period(sut):
-                return assert_output_equals(sut.autoscaling_alarm.evaluation_periods, 1)
+                return assert_output_equals(sut.autoscaling_out_alarm.evaluation_periods, 1)
 
             @pulumi.runtime.test
             def it_triggers_based_on_CPU_utilization(sut):
-                return assert_output_equals(sut.autoscaling_alarm.metric_name, "CPUUtilization")
+                return assert_output_equals(sut.autoscaling_out_alarm.metric_name, "CPUUtilization")
 
             @pulumi.runtime.test
             def it_checks_the_unit_as_a_percentage(sut):
-                return assert_output_equals(sut.autoscaling_alarm.unit, "Percent")
+                return assert_output_equals(sut.autoscaling_out_alarm.unit, "Percent")
 
             @pulumi.runtime.test
             def it_pulls_the_metric_data_from_the_cluster(sut):
-                return assert_output_equals(sut.autoscaling_alarm.dimensions["ClusterName"], sut.project_stack)
+                return assert_output_equals(sut.autoscaling_out_alarm.dimensions["ClusterName"], sut.project_stack)
 
             @pulumi.runtime.test
             def it_pulls_the_metric_data_from_the_service(sut):
-                return assert_output_equals(sut.autoscaling_alarm.dimensions["ServiceName"], sut.project_stack)
+                return assert_output_equals(sut.autoscaling_out_alarm.dimensions["ServiceName"], sut.project_stack)
 
             @pulumi.runtime.test
             def it_belongs_to_the_ECS_namespace(sut):
-                return assert_output_equals(sut.autoscaling_alarm.namespace, "AWS/ECS")
+                return assert_output_equals(sut.autoscaling_out_alarm.namespace, "AWS/ECS")
 
             @pulumi.runtime.test
             def it_runs_every_minute(sut):
-                return assert_output_equals(sut.autoscaling_alarm.period, 60)
+                return assert_output_equals(sut.autoscaling_out_alarm.period, 60)
 
             @pulumi.runtime.test
             def it_uses_average_statistic_by_default(sut):
-                return assert_output_equals(sut.autoscaling_alarm.statistic, "Average")
+                return assert_output_equals(sut.autoscaling_out_alarm.statistic, "Average")
 
             @pulumi.runtime.test
             def it_triggers_when_CPU_utilization_is_over_65(sut):
-                return assert_output_equals(sut.autoscaling_alarm.threshold, 65)
+                return assert_output_equals(sut.autoscaling_out_alarm.threshold, 65)
 
             @pulumi.runtime.test
             def it_triggers_the_autoscaling_policy(sut):
-                return assert_outputs_equal(sut.autoscaling_alarm.alarm_actions, [sut.autoscaling_policy.arn])
+                return assert_outputs_equal(sut.autoscaling_out_alarm.alarm_actions, [sut.autoscaling_out_policy.arn])
+
 
         def describe_autoscaling_policy():
             @pulumi.runtime.test
             def it_exists(sut):
-                assert sut.autoscaling_policy
+                assert sut.autoscaling_out_policy
 
             @pulumi.runtime.test
             def it_has_a_step_scaling_policy_type(sut):
-                return assert_output_equals(sut.autoscaling_policy.policy_type, "StepScaling")
+                return assert_output_equals(sut.autoscaling_out_policy.policy_type, "StepScaling")
 
             @pulumi.runtime.test
             def it_uses_the_clusters_resource_id(sut):
                 resource_id = f"service/{sut.project_stack}/{sut.project_stack}"
-                return assert_output_equals(sut.autoscaling_policy.resource_id, resource_id)
+                return assert_output_equals(sut.autoscaling_out_policy.resource_id, resource_id)
 
             @pulumi.runtime.test
             def it_has_a_default_scalable_dimension_of_desired_count(sut):
-                return assert_output_equals(sut.autoscaling_policy.scalable_dimension, "ecs:service:DesiredCount")
+                return assert_output_equals(sut.autoscaling_out_policy.scalable_dimension, "ecs:service:DesiredCount")
 
             @pulumi.runtime.test
             def it_has_a_default_service_namespace(sut):
-                return assert_output_equals(sut.autoscaling_policy.service_namespace, "ecs")
+                return assert_output_equals(sut.autoscaling_out_policy.service_namespace, "ecs")
 
             @pulumi.runtime.test
             def it_has_a_step_scaling_policy_configuration(sut):
-                assert sut.autoscaling_policy.step_scaling_policy_configuration
+                assert sut.autoscaling_out_policy.step_scaling_policy_configuration
 
             @pulumi.runtime.test
             def it_has_a_default_cooldown(sut):
-                return assert_output_equals(sut.autoscaling_policy.step_scaling_policy_configuration.cooldown, 60)
+                return assert_output_equals(sut.autoscaling_out_policy.step_scaling_policy_configuration.cooldown, 60)
 
             @pulumi.runtime.test
             def it_changes_capacity(sut):
-                return assert_output_equals(sut.autoscaling_policy.step_scaling_policy_configuration.adjustment_type, "ChangeInCapacity")
+                return assert_output_equals(sut.autoscaling_out_policy.step_scaling_policy_configuration.adjustment_type, "ChangeInCapacity")
 
             @pulumi.runtime.test
             def it_has_a_default_maximum_metric_aggregation_type(sut):
-                return assert_output_equals(sut.autoscaling_policy.step_scaling_policy_configuration.metric_aggregation_type, "Maximum")
+                return assert_output_equals(sut.autoscaling_out_policy.step_scaling_policy_configuration.metric_aggregation_type, "Maximum")
 
             @pulumi.runtime.test
             def it_has_steps(sut):
-                assert sut.autoscaling_policy.step_scaling_policy_configuration.step_adjustments
+                assert sut.autoscaling_out_policy.step_scaling_policy_configuration.step_adjustments
 
             def describe_first_step():
                 @pytest.fixture
                 def step(sut):
-                    return sut.autoscaling_policy.step_scaling_policy_configuration.step_adjustments[0]
+                    return sut.autoscaling_out_policy.step_scaling_policy_configuration.step_adjustments[0]
 
                 @pulumi.runtime.test
                 def it_triggers_when_it_exceeds_the_alarm_threshold(step):
@@ -647,7 +648,7 @@ def describe_a_pulumi_containerized_app():
             def describe_second_step():
                 @pytest.fixture
                 def step(sut):
-                    return sut.autoscaling_policy.step_scaling_policy_configuration.step_adjustments[1]
+                    return sut.autoscaling_out_policy.step_scaling_policy_configuration.step_adjustments[1]
 
                 @pulumi.runtime.test
                 def it_triggers_when_it_exceeds_the_alarm_threshold_by_more_than_ten(step):

--- a/deployment/src/tests/test_container_autoscaling.py
+++ b/deployment/src/tests/test_container_autoscaling.py
@@ -150,6 +150,10 @@ def describe_autoscaling():
             def it_triggers_when_CPU_utilization_is_under_50(sut):
                 return assert_output_equals(sut.autoscaling_in_alarm.threshold, 50)
 
+            @pulumi.runtime.test
+            def it_triggers_the_autoscaling_policy(sut):
+                return assert_outputs_equal(sut.autoscaling_in_alarm.alarm_actions, [sut.autoscaling_in_policy.arn])
+
         def describe_autoscaling_in_policy():
             def it_exists(sut):
                 assert sut.autoscaling_in_policy

--- a/deployment/src/tests/test_container_autoscaling.py
+++ b/deployment/src/tests/test_container_autoscaling.py
@@ -54,6 +54,10 @@ def describe_autoscaling():
                 assert sut.autoscaling_out_alarm
 
             @pulumi.runtime.test
+            def it_is_named_auto_scaling_out_alarm(sut, app_name, stack):
+                return assert_output_equals(sut.autoscaling_out_alarm.name, f"{app_name}-{stack}-auto-scaling-out-alarm")
+
+            @pulumi.runtime.test
             def it_triggers_when_greater_than_or_equal_to_threshold(sut):
                 return assert_output_equals(sut.autoscaling_out_alarm.comparison_operator, "GreaterThanOrEqualToThreshold")
 
@@ -97,10 +101,112 @@ def describe_autoscaling():
             def it_triggers_the_autoscaling_policy(sut):
                 return assert_outputs_equal(sut.autoscaling_out_alarm.alarm_actions, [sut.autoscaling_out_policy.arn])
 
+        def describe_autoscaling_in_alarm():
+            def it_exists(sut):
+                assert sut.autoscaling_in_alarm
+
+            @pulumi.runtime.test
+            def it_is_named_auto_scaling_in_alarm(sut, app_name, stack):
+                return assert_output_equals(sut.autoscaling_in_alarm.name,
+                                            f"{app_name}-{stack}-auto-scaling-in-alarm")
+
+            @pulumi.runtime.test
+            def it_triggers_when_less_than_or_equal_to_threshold(sut):
+                return assert_output_equals(sut.autoscaling_in_alarm.comparison_operator, "LessThanOrEqualToThreshold")
+
+            @pulumi.runtime.test
+            def it_evaluates_for_five_periods(sut):
+                return assert_output_equals(sut.autoscaling_in_alarm.evaluation_periods, 5)
+
+            @pulumi.runtime.test
+            def it_triggers_based_on_CPU_utilization(sut):
+                return assert_output_equals(sut.autoscaling_in_alarm.metric_name, "CPUUtilization")
+
+            @pulumi.runtime.test
+            def it_checks_the_unit_as_a_percentage(sut):
+                return assert_output_equals(sut.autoscaling_in_alarm.unit, "Percent")
+
+            @pulumi.runtime.test
+            def it_pulls_the_metric_data_from_the_cluster(sut):
+                return assert_output_equals(sut.autoscaling_in_alarm.dimensions["ClusterName"], sut.project_stack)
+
+            @pulumi.runtime.test
+            def it_pulls_the_metric_data_from_the_service(sut):
+                return assert_output_equals(sut.autoscaling_in_alarm.dimensions["ServiceName"], sut.project_stack)
+
+            @pulumi.runtime.test
+            def it_belongs_to_the_ECS_namespace(sut):
+                return assert_output_equals(sut.autoscaling_in_alarm.namespace, "AWS/ECS")
+
+            @pulumi.runtime.test
+            def it_runs_every_minute(sut):
+                return assert_output_equals(sut.autoscaling_in_alarm.period, 60)
+
+            @pulumi.runtime.test
+            def it_uses_average_statistic_by_default(sut):
+                return assert_output_equals(sut.autoscaling_in_alarm.statistic, "Average")
+
+            @pulumi.runtime.test
+            def it_triggers_when_CPU_utilization_is_under_50(sut):
+                return assert_output_equals(sut.autoscaling_in_alarm.threshold, 50)
+
+        def describe_autoscaling_in_policy():
+            def it_exists(sut):
+                assert sut.autoscaling_in_policy
+
+            @pulumi.runtime.test
+            def it_is_named_autoscaling_in_policy(sut, app_name, stack):
+                return assert_output_equals(sut.autoscaling_in_policy.name, f"{app_name}-{stack}-autoscaling-in-policy")
+
+            @pulumi.runtime.test
+            def it_has_a_step_scaling_policy_type(sut):
+                return assert_output_equals(sut.autoscaling_in_policy.policy_type, "StepScaling")
+
+            @pulumi.runtime.test
+            def it_uses_the_clusters_resource_id(sut):
+                resource_id = f"service/{sut.project_stack}/{sut.project_stack}"
+                return assert_output_equals(sut.autoscaling_in_policy.resource_id, resource_id)
+
+            @pulumi.runtime.test
+            def it_has_a_default_scalable_dimension_of_desired_count(sut):
+                return assert_output_equals(sut.autoscaling_in_policy.scalable_dimension, "ecs:service:DesiredCount")
+
+            @pulumi.runtime.test
+            def it_has_a_default_service_namespace(sut):
+                return assert_output_equals(sut.autoscaling_in_policy.service_namespace, "ecs")
+
+            @pulumi.runtime.test
+            def it_has_a_step_scaling_policy_configuration(sut):
+                assert sut.autoscaling_in_policy.step_scaling_policy_configuration
+
+            @pulumi.runtime.test
+            def it_has_a_default_cooldown(sut):
+                return assert_output_equals(sut.autoscaling_in_policy.step_scaling_policy_configuration.cooldown, 60)
+
+            @pulumi.runtime.test
+            def it_changes_capacity(sut):
+                return assert_output_equals(sut.autoscaling_in_policy.step_scaling_policy_configuration.adjustment_type,
+                                            "ChangeInCapacity")
+
+            @pulumi.runtime.test
+            def it_has_a_default_minimum_metric_aggregation_type(sut):
+                return assert_output_equals(
+                    sut.autoscaling_in_policy.step_scaling_policy_configuration.metric_aggregation_type, "Maximum")
+
+            @pulumi.runtime.test
+            def it_has_steps(sut):
+                assert sut.autoscaling_in_policy.step_scaling_policy_configuration.step_adjustments
+                
+
         def describe_autoscaling_out_policy():
             @pulumi.runtime.test
             def it_exists(sut):
                 assert sut.autoscaling_out_policy
+
+            @pulumi.runtime.test
+            def it_is_named_autoscaling_out_policy(sut, app_name, stack):
+                return assert_output_equals(sut.autoscaling_out_policy.name,
+                                            f"{app_name}-{stack}-autoscaling-out-policy")
 
             @pulumi.runtime.test
             def it_has_a_step_scaling_policy_type(sut):

--- a/deployment/src/tests/test_container_autoscaling.py
+++ b/deployment/src/tests/test_container_autoscaling.py
@@ -196,7 +196,23 @@ def describe_autoscaling():
             @pulumi.runtime.test
             def it_has_steps(sut):
                 assert sut.autoscaling_in_policy.step_scaling_policy_configuration.step_adjustments
-                
+
+            def describe_step():
+                @pytest.fixture
+                def step(sut):
+                    return sut.autoscaling_in_policy.step_scaling_policy_configuration.step_adjustments[0]
+
+                @pulumi.runtime.test
+                def it_has_no_lower_bound(step):
+                    return assert_output_equals(step.metric_interval_lower_bound, None)
+
+                @pulumi.runtime.test
+                def it_triggers_when_it_is_below_the_alarm_threshold(step):
+                    return assert_output_equals(step.metric_interval_upper_bound, "0")
+
+                @pulumi.runtime.test
+                def it_scales_up_by_one_instance(step):
+                    return assert_output_equals(step.scaling_adjustment, 1)
 
         def describe_autoscaling_out_policy():
             @pulumi.runtime.test

--- a/deployment/src/tests/test_container_autoscaling.py
+++ b/deployment/src/tests/test_container_autoscaling.py
@@ -1,0 +1,176 @@
+import pulumi
+import pytest
+from pytest_describe import behaves_like
+
+from tests.shared import assert_output_equals, assert_outputs_equal
+from tests.test_container import a_pulumi_containerized_app
+
+
+@behaves_like(a_pulumi_containerized_app)
+def describe_autoscaling():
+    def describe_when_turned_on():
+        @pytest.fixture
+        def component_kwargs(component_kwargs):
+            component_kwargs["autoscaling"] = True
+            return component_kwargs
+        @pulumi.runtime.test
+        def it_has_an_autoscaling_target(sut):
+            assert sut.autoscaling_target
+
+        @pulumi.runtime.test
+        def it_has_a_default_max_capacity(sut):
+            return assert_output_equals(sut.autoscaling_target.max_capacity, 1)
+
+        def describe_autoscaling_overrides():
+            @pytest.fixture
+            def component_kwargs(component_kwargs):
+                component_kwargs["max_number_of_instances"] = 10
+                return component_kwargs
+
+            @pulumi.runtime.test
+            def it_has_a_configurable_max_capacity(sut):
+                return assert_output_equals(sut.autoscaling_target.max_capacity, 10)
+
+        @pulumi.runtime.test
+        def it_has_a_default_min_capacity(sut):
+            return assert_output_equals(sut.autoscaling_target.min_capacity, 1)
+
+        @pulumi.runtime.test
+        def it_has_a_default_scalable_dimension_of_desired_count(sut):
+            return assert_output_equals(sut.autoscaling_target.scalable_dimension, "ecs:service:DesiredCount")
+
+        @pulumi.runtime.test
+        def it_uses_the_default_service_namespace_of_ecs(sut):
+            return assert_output_equals(sut.autoscaling_target.service_namespace, "ecs")
+
+        @pulumi.runtime.test
+        def it_uses_the_clusters_resource_id(sut):
+            resource_id = f"service/{sut.project_stack}/{sut.project_stack}"
+            return assert_output_equals(sut.autoscaling_target.resource_id, resource_id)
+
+        def describe_autoscaling_out_alarm():
+            @pulumi.runtime.test
+            def it_exists(sut):
+                assert sut.autoscaling_out_alarm
+
+            @pulumi.runtime.test
+            def it_triggers_when_greater_than_or_equal_to_threshold(sut):
+                return assert_output_equals(sut.autoscaling_out_alarm.comparison_operator, "GreaterThanOrEqualToThreshold")
+
+            @pulumi.runtime.test
+            def it_evaluates_for_one_period(sut):
+                return assert_output_equals(sut.autoscaling_out_alarm.evaluation_periods, 1)
+
+            @pulumi.runtime.test
+            def it_triggers_based_on_CPU_utilization(sut):
+                return assert_output_equals(sut.autoscaling_out_alarm.metric_name, "CPUUtilization")
+
+            @pulumi.runtime.test
+            def it_checks_the_unit_as_a_percentage(sut):
+                return assert_output_equals(sut.autoscaling_out_alarm.unit, "Percent")
+
+            @pulumi.runtime.test
+            def it_pulls_the_metric_data_from_the_cluster(sut):
+                return assert_output_equals(sut.autoscaling_out_alarm.dimensions["ClusterName"], sut.project_stack)
+
+            @pulumi.runtime.test
+            def it_pulls_the_metric_data_from_the_service(sut):
+                return assert_output_equals(sut.autoscaling_out_alarm.dimensions["ServiceName"], sut.project_stack)
+
+            @pulumi.runtime.test
+            def it_belongs_to_the_ECS_namespace(sut):
+                return assert_output_equals(sut.autoscaling_out_alarm.namespace, "AWS/ECS")
+
+            @pulumi.runtime.test
+            def it_runs_every_minute(sut):
+                return assert_output_equals(sut.autoscaling_out_alarm.period, 60)
+
+            @pulumi.runtime.test
+            def it_uses_average_statistic_by_default(sut):
+                return assert_output_equals(sut.autoscaling_out_alarm.statistic, "Average")
+
+            @pulumi.runtime.test
+            def it_triggers_when_CPU_utilization_is_over_65(sut):
+                return assert_output_equals(sut.autoscaling_out_alarm.threshold, 65)
+
+            @pulumi.runtime.test
+            def it_triggers_the_autoscaling_policy(sut):
+                return assert_outputs_equal(sut.autoscaling_out_alarm.alarm_actions, [sut.autoscaling_out_policy.arn])
+
+        def describe_autoscaling_out_policy():
+            @pulumi.runtime.test
+            def it_exists(sut):
+                assert sut.autoscaling_out_policy
+
+            @pulumi.runtime.test
+            def it_has_a_step_scaling_policy_type(sut):
+                return assert_output_equals(sut.autoscaling_out_policy.policy_type, "StepScaling")
+
+            @pulumi.runtime.test
+            def it_uses_the_clusters_resource_id(sut):
+                resource_id = f"service/{sut.project_stack}/{sut.project_stack}"
+                return assert_output_equals(sut.autoscaling_out_policy.resource_id, resource_id)
+
+            @pulumi.runtime.test
+            def it_has_a_default_scalable_dimension_of_desired_count(sut):
+                return assert_output_equals(sut.autoscaling_out_policy.scalable_dimension, "ecs:service:DesiredCount")
+
+            @pulumi.runtime.test
+            def it_has_a_default_service_namespace(sut):
+                return assert_output_equals(sut.autoscaling_out_policy.service_namespace, "ecs")
+
+            @pulumi.runtime.test
+            def it_has_a_step_scaling_policy_configuration(sut):
+                assert sut.autoscaling_out_policy.step_scaling_policy_configuration
+
+            @pulumi.runtime.test
+            def it_has_a_default_cooldown(sut):
+                return assert_output_equals(sut.autoscaling_out_policy.step_scaling_policy_configuration.cooldown, 60)
+
+            @pulumi.runtime.test
+            def it_changes_capacity(sut):
+                return assert_output_equals(sut.autoscaling_out_policy.step_scaling_policy_configuration.adjustment_type,
+                                            "ChangeInCapacity")
+
+            @pulumi.runtime.test
+            def it_has_a_default_maximum_metric_aggregation_type(sut):
+                return assert_output_equals(
+                    sut.autoscaling_out_policy.step_scaling_policy_configuration.metric_aggregation_type, "Maximum")
+
+            @pulumi.runtime.test
+            def it_has_steps(sut):
+                assert sut.autoscaling_out_policy.step_scaling_policy_configuration.step_adjustments
+
+            def describe_first_step():
+                @pytest.fixture
+                def step(sut):
+                    return sut.autoscaling_out_policy.step_scaling_policy_configuration.step_adjustments[0]
+
+                @pulumi.runtime.test
+                def it_triggers_when_it_exceeds_the_alarm_threshold(step):
+                    return assert_output_equals(step.metric_interval_lower_bound, "0")
+
+                @pulumi.runtime.test
+                def it_triggers_when_it_exceeds_the_alarm_threshold_by_up_to_ten(step):
+                    return assert_output_equals(step.metric_interval_upper_bound, "10")
+
+                @pulumi.runtime.test
+                def it_scales_up_by_one_instance(step):
+                    return assert_output_equals(step.scaling_adjustment, 1)
+
+            def describe_second_step():
+                @pytest.fixture
+                def step(sut):
+                    return sut.autoscaling_out_policy.step_scaling_policy_configuration.step_adjustments[1]
+
+                @pulumi.runtime.test
+                def it_triggers_when_it_exceeds_the_alarm_threshold_by_more_than_ten(step):
+                    return assert_output_equals(step.metric_interval_lower_bound, "10")
+
+                @pulumi.runtime.test
+                def it_triggers_at_all_higher_values_than_ten(step):
+                    return assert_output_equals(step.metric_interval_upper_bound, None)
+
+                @pulumi.runtime.test
+                def it_scales_up_by_three_instances(step):
+                    return assert_output_equals(step.scaling_adjustment, 3)


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-1378)

## Purpose 
When we have scaled out horizontally because of CPU usage too high, we also need to scale in because of usage that is too low.

## Approach 
Use the same policies/alarms we used for scale out, but scale in at an average usage of under 50% over 5 minutes.

## Testing
Ran frozen-desserts-prod deployment locally.

## Screenshots/Video
Before:
![image](https://github.com/StrongMind/public-reusable-workflows/assets/3137263/2b12ea25-6b20-488f-a61d-225df1381830)

After:
![image](https://github.com/StrongMind/public-reusable-workflows/assets/3137263/d75ce448-822f-4752-8527-66df3a66fc71)

