### PR TITLE
Set final snapshot identifier

### DIFF
--- a/deployment/pyproject.toml
+++ b/deployment/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "strongmind_deployment"
-version = "1.1.21"
+version = "1.1.23"
 
 authors = [
   { name="Belding", email="teambelding@strongmind.com" },

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -281,6 +281,7 @@ class RailsComponent(pulumi.ComponentResource):
             apply_immediately=True,
             deletion_protection=True,
             skip_final_snapshot=False,
+            final_snapshot_identifier=f'{project_stack}-final-snapshot',
             backup_retention_period=14,
             serverlessv2_scaling_configuration=aws.rds.ClusterServerlessv2ScalingConfigurationArgs(
                 min_capacity=0.5,

--- a/deployment/src/tests/test_rails.py
+++ b/deployment/src/tests/test_rails.py
@@ -360,6 +360,10 @@ def describe_a_pulumi_rails_app():
             return assert_output_equals(sut.rds_serverless_cluster.skip_final_snapshot, False)
 
         @pulumi.runtime.test
+        def it_sets_final_snapshot_identifier(sut, app_name, stack):
+            return assert_output_equals(sut.rds_serverless_cluster.final_snapshot_identifier, f"{app_name}-{stack}-final-snapshot")
+
+        @pulumi.runtime.test
         def it_sets_the_backup_retention_period_to_14_days(sut):
             return assert_output_equals(sut.rds_serverless_cluster.backup_retention_period, 14)
 


### PR DESCRIPTION
## Purpose 
Hit this when running pulumi destroy on frozen-desserts-stage
<img width="1091" alt="Screenshot 2023-09-22 at 12 19 59 PM" src="https://github.com/StrongMind/public-reusable-workflows/assets/3137263/fca8ca47-8277-4364-97f9-7fd9ab0c202b">

## Approach 
Set a final snapshot identifier so that AWS can take a final snapshot when removing an environment.

## Testing
Ran on frozen desserts and it set properly.

## Screenshots/Video
![image](https://github.com/StrongMind/public-reusable-workflows/assets/3137263/6c4340c2-ae77-4b0a-a92b-63e6dfaeb5dd)