### PR TITLE
(B) SKNK-805 - Add Selenium standalone Chrome service and setup Chrome

### DIFF
--- a/.github/workflows/rspec-test.yml
+++ b/.github/workflows/rspec-test.yml
@@ -13,6 +13,9 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     services:
+      selenium:
+        image: selenium/standalone-chrome:latest
+        options: --shm-size="2g"
       postgres:
         image: postgres:latest
         env:
@@ -26,10 +29,13 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
-      
+
+      - name: Setup Chrome
+        uses: browser-actions/setup-chrome@latest
+
       - name: Start Postgres
         run: sudo systemctl start postgresql.service
-      
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
[SKNK-805](https://strongmind.atlassian.net/browse/SKNK-805)

## Purpose 
PS. This is untested, and we are unsure if this will fix our issue

The RSpec test workflow does not account for Capybara integration testing
This will add a driver (hopefully) to allow the workflow to be able to run Capybara tests with a headless browser successfully

## Approach 
1. Add Selenium Chrome as a service that allows us to run a Selenium server with the Chrome browser
2.  Allocate two GB of shared memory for the service
2.  Set it up using a 3rd party action that ensures the Chrome browser is installed and available for Selenium to control during the tests.

## Testing
This is untested.

## Screenshots/Video
Error:
![image](https://github.com/StrongMind/public-reusable-workflows/assets/65372461/1b37d6ed-1463-4a9a-b6e6-572e549f12cf)



[SKNK-805]: https://strongmind.atlassian.net/browse/SKNK-805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ