### PR TITLE
Skip reporting coverage if we don't have it in place for the repo

### DIFF
--- a/.github/workflows/rspec-test.yml
+++ b/.github/workflows/rspec-test.yml
@@ -43,8 +43,25 @@ jobs:
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
           RAILS_ENV: test
 
+      - name: Check for Secret availability
+        id: secret-check
+        # perform secret check & put boolean result as an output
+        shell: bash
+        run: |
+          if [ "${{ secrets.CC_TEST_REPORTER_ID }}" != '' ]; then
+            echo "available=true" >> $GITHUB_OUTPUT;
+          else
+            echo "available=false" >> $GITHUB_OUTPUT;
+          fi
+          
+      - name: Test
+        if: ${{ steps.secret-check.outputs.available != 'true' }}
+        run: |
+          bundle exec rspec
+
       - name: Test & publish code coverage
         uses: paambaati/codeclimate-action@v5.0.0
+        if: ${{ steps.secret-check.outputs.available == 'true' }}
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}


### PR DESCRIPTION
## Purpose 
When setting up new apps, we have not said that reporting code coverage is REQUIRED for deployment. But this step currently enforces that.

## Approach 
Only report code coverage if the CC_TEST_REPORTER_ID secret is in place for the repo.
Used code from https://stackoverflow.com/questions/70249519/how-to-check-if-a-secret-variable-is-empty-in-if-conditional-github-actions
