### PR TITLE
BEL-1335 Worker cmd override and web cmd default

### DIFF
--- a/deployment/pyproject.toml
+++ b/deployment/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "strongmind_deployment"
-version = "1.1.23"
+version = "1.1.24"
 
 authors = [
   { name="Belding", email="teambelding@strongmind.com" },

--- a/deployment/pyproject.toml
+++ b/deployment/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "strongmind_deployment"
-version = "1.1.24"
+version = "1.1.25"
 
 authors = [
   { name="Belding", email="teambelding@strongmind.com" },

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -32,10 +32,12 @@ class RailsComponent(pulumi.ComponentResource):
         :key execution_cmd: The command for the pre-deployment execution container. Defaults to ["sh", "-c",
                                       "bundle exec rails db:prepare db:migrate db:seed && echo 'Migrations complete'"].
         :key web_entry_point: The entry point for the web container. Defaults to the ENTRYPOINT in the Dockerfile.
+        :key web_cmd: The command for the web container. Defaults to the CMD in the Dockerfile.
         :key cpu: The number of CPU units to reserve for the web container. Defaults to 256.
         :key memory: The amount of memory (in MiB) to allow the web container to use. Defaults to 512.
         :key need_worker: Whether to create a worker container. Defaults to True if sidekiq is in the Gemfile.
-        :key worker_entry_point: The entry point for the worker container. Defaults to `["sh", "-c", "bundle exec sidekiq"]`. Requires need_worker to be True.
+        :key worker_entry_point: The entry point for the worker container. Defaults to the ENTRYPOINT in the Dockerfile. Requires need_worker to be True.
+        :key worker_cmd: The command for the worker container. Defaults `["sh", "-c", "bundle exec sidekiq"]`. Requires need_worker to be True.
         :key worker_cpu: The number of CPU units to reserve for the worker container. Defaults to 256.
         :key worker_memory: The amount of memory (in MiB) to allow the worker container to use. Defaults to 512.
         :key worker_log_metric_filters: A list of log metric filters to create for the worker container. Defaults to `[]`.
@@ -207,9 +209,11 @@ class RailsComponent(pulumi.ComponentResource):
                                                                         depends_on=[self.migration_container]))
 
         web_entry_point = self.kwargs.get('web_entry_point')
+        web_command = self.kwargs.get('web_cmd')
 
         self.kwargs['secrets'] = self.secret.get_secrets()  # pragma: no cover
         self.kwargs['entry_point'] = web_entry_point
+        self.kwargs['command'] = web_command
         self.web_container = ContainerComponent("container",
                                                 pulumi.ResourceOptions(parent=self,
                                                                        depends_on=[self.execution]

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -180,6 +180,8 @@ class RailsComponent(pulumi.ComponentResource):
                                          "bundle exec rails db:prepare db:migrate db:seed && "
                                          "echo 'Migrations complete'"])
         self.kwargs['command'] = execution_cmd
+
+
         self.migration_container = ContainerComponent("migration",
                                                       need_load_balancer=False,
                                                       desired_count=0,
@@ -227,10 +229,12 @@ class RailsComponent(pulumi.ComponentResource):
             self.setup_storage()
 
     def setup_worker(self):  # , execution):
-        worker_entry_point = self.kwargs.get('worker_entry_point', ["sh", "-c", "bundle exec sidekiq"])
+        worker_cmd = self.kwargs.get('worker_cmd', ["sh", "-c", "bundle exec sidekiq"])
+        worker_entry_point = self.kwargs.get('worker_entry_point')
         if "WORKER_CONTAINER_IMAGE" in os.environ:
             self.kwargs['container_image'] = os.environ["WORKER_CONTAINER_IMAGE"]
         self.kwargs['entry_point'] = worker_entry_point
+        self.kwargs['command'] = worker_cmd
         self.kwargs['cpu'] = self.kwargs.get('worker_cpu')
         self.kwargs['memory'] = self.kwargs.get('worker_memory')
         self.kwargs['ecs_cluster_arn'] = self.ecs_cluster.arn

--- a/deployment/src/tests/test_rails.py
+++ b/deployment/src/tests/test_rails.py
@@ -46,6 +46,11 @@ def a_pulumi_rails_app():
         return None
 
     @pytest.fixture
+    def container_cmd():
+        # We will use the command from Dockerfile by default
+        return None
+
+    @pytest.fixture
     def worker_container_memory(faker):
         return faker.random_int()
 
@@ -598,6 +603,10 @@ def describe_a_pulumi_rails_component():
         @pulumi.runtime.test
         def it_uses_rails_entry_point(sut, container_entry_point):
             assert sut.web_container.entry_point == container_entry_point
+
+        @pulumi.runtime.test
+        def it_uses_rails_command(sut, container_cmd):
+            assert sut.web_container.command == container_cmd
 
         @pulumi.runtime.test
         def it_uses_empty_entry_point_for_execution(sut):

--- a/deployment/src/tests/test_rails.py
+++ b/deployment/src/tests/test_rails.py
@@ -617,66 +617,7 @@ def describe_a_pulumi_rails_component():
             def it_uses_custom_command_for_execution(sut, execution_container_cmd):
                 assert sut.migration_container.command == execution_container_cmd
 
-        def describe_with_need_worker_set():
-            @pytest.fixture
-            def component_kwargs(component_kwargs):
-                component_kwargs['need_worker'] = True
-                return component_kwargs
 
-            @pulumi.runtime.test
-            def it_creates_a_worker_container_component(sut,
-                                                        worker_container_cpu,
-                                                        worker_container_memory):
-                def check_machine_specs(args):
-                    container_cpu, container_memory = args
-                    assert container_cpu == worker_container_cpu
-                    assert container_memory == worker_container_memory
-
-                return pulumi.Output.all(
-                    sut.worker_container.cpu,
-                    sut.worker_container.memory
-                ).apply(check_machine_specs)
-
-            @pulumi.runtime.test
-            def it_uses_sidekiq_entry_point_for_worker(sut, worker_container_entry_point):
-                assert sut.worker_container.entry_point == worker_container_entry_point
-
-            @pulumi.runtime.test
-            def it_does_not_need_load_balancer(sut):
-                assert not sut.worker_container.need_load_balancer
-
-            @pulumi.runtime.test
-            def it_uses_cluster_from_web_container(sut):
-                assert sut.worker_container.ecs_cluster_arn == sut.web_container.ecs_cluster_arn
-
-            def describe_worker_log_metric_filters():
-                @pytest.fixture
-                def worker_log_metric_filters(faker):
-                    return [
-                    {
-                        "pattern": "BLAH DAH",
-                        "metric_transformation": {
-                            "name": "waiting_workers",
-                            "namespace": "Jobs",
-                            "value": "$BLAH",
-                        }
-                    }
-                ]
-
-                @pytest.fixture
-                def component_kwargs(component_kwargs, worker_log_metric_filters):
-                    component_kwargs['worker_log_metric_filters'] = worker_log_metric_filters
-                    return component_kwargs
-
-                @pulumi.runtime.test
-                def it_passes_worker_log_metric_filter_pattern_to_worker_container(sut, worker_log_metric_filters):
-                    return assert_output_equals(sut.worker_container.log_metric_filters[0].pattern,
-                                                "BLAH DAH")
-
-                @pulumi.runtime.test
-                def it_passes_worker_log_metric_filter_value_to_worker_container(sut, worker_log_metric_filters):
-                    return assert_output_equals(sut.worker_container.log_metric_filters[0].metric_transformation.value,
-                                                "$BLAH")
 
     @pulumi.runtime.test
     def it_allows_container_to_talk_to_rds(sut, ecs_security_groups):

--- a/deployment/src/tests/test_rails_worker.py
+++ b/deployment/src/tests/test_rails_worker.py
@@ -1,0 +1,85 @@
+import pulumi
+import pytest
+from pytest_describe import behaves_like
+
+from tests.shared import assert_output_equals
+from tests.test_rails import a_pulumi_rails_app
+
+
+@behaves_like(a_pulumi_rails_app)
+def describe_a_pulumi_rails_app():
+    def describe_with_need_worker_set():
+        @pytest.fixture
+        def component_kwargs(component_kwargs):
+            component_kwargs['need_worker'] = True
+            return component_kwargs
+
+        @pulumi.runtime.test
+        def it_creates_a_worker_container_component(sut,
+                                                    worker_container_cpu,
+                                                    worker_container_memory):
+            def check_machine_specs(args):
+                container_cpu, container_memory = args
+                assert container_cpu == worker_container_cpu
+                assert container_memory == worker_container_memory
+
+            return pulumi.Output.all(
+                sut.worker_container.cpu,
+                sut.worker_container.memory
+            ).apply(check_machine_specs)
+
+        @pulumi.runtime.test
+        def it_uses_sidekiq_entry_point_for_worker(sut, worker_container_entry_point):
+            assert sut.worker_container.entry_point == worker_container_entry_point
+
+        @pulumi.runtime.test
+        def it_uses_sidekiq_as_a_default_cmd(sut):
+            assert sut.worker_container.command == ["sh", "-c", "bundle exec sidekiq"]
+
+        def describe_with_a_custom_cmd():
+            @pytest.fixture
+            def component_kwargs(component_kwargs):
+                component_kwargs['worker_cmd'] = ["sh", "-c", "/usr/src/worker.sh"]
+                return component_kwargs
+
+            @pulumi.runtime.test
+            def it_uses_the_custom_command(sut):
+                assert sut.worker_container.command == ["sh", "-c", "/usr/src/worker.sh"]
+
+
+        @pulumi.runtime.test
+        def it_does_not_need_load_balancer(sut):
+            assert not sut.worker_container.need_load_balancer
+
+        @pulumi.runtime.test
+        def it_uses_cluster_from_web_container(sut):
+            assert sut.worker_container.ecs_cluster_arn == sut.web_container.ecs_cluster_arn
+
+        def describe_worker_log_metric_filters():
+            @pytest.fixture
+            def worker_log_metric_filters(faker):
+                return [
+                    {
+                        "pattern": "BLAH DAH",
+                        "metric_transformation": {
+                            "name": "waiting_workers",
+                            "namespace": "Jobs",
+                            "value": "$BLAH",
+                        }
+                    }
+                ]
+
+            @pytest.fixture
+            def component_kwargs(component_kwargs, worker_log_metric_filters):
+                component_kwargs['worker_log_metric_filters'] = worker_log_metric_filters
+                return component_kwargs
+
+            @pulumi.runtime.test
+            def it_passes_worker_log_metric_filter_pattern_to_worker_container(sut, worker_log_metric_filters):
+                return assert_output_equals(sut.worker_container.log_metric_filters[0].pattern,
+                                            "BLAH DAH")
+
+            @pulumi.runtime.test
+            def it_passes_worker_log_metric_filter_value_to_worker_container(sut, worker_log_metric_filters):
+                return assert_output_equals(sut.worker_container.log_metric_filters[0].metric_transformation.value,
+                                            "$BLAH")


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-1335)

## Purpose 
So that we can deploy the canvas workers

## Approach 
Allow `worker_cmd` to be sent to the worker via the rails component. Remove the default entrypoint and move it to the cmd.

## Testing
Tested using the frozen-desserts repo.
