### PR TITLE
(B) BEL-1703 Turn on enable_execute_command

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -210,6 +210,7 @@ class ContainerComponent(pulumi.ComponentResource):
             assign_public_ip=True,
             health_check_grace_period_seconds=600 if self.need_load_balancer else None,
             propagate_tags="SERVICE",
+            enable_execute_command=True,
             task_definition_args=self.task_definition_args,
             tags=self.tags,
             opts=pulumi.ResourceOptions(parent=self),

--- a/deployment/src/tests/mocks.py
+++ b/deployment/src/tests/mocks.py
@@ -31,6 +31,7 @@ def get_pulumi_mocks(faker, fake_password=None, secret_string="{}"):
                     "task_definition_args": args.inputs["taskDefinitionArgs"],
                     "task_definition": TaskDefinitionMock(),
                     "propagate_tags": args.inputs.get("propagateTags"),
+                    "enable_execute_command": args.inputs.get("enableExecuteCommand"),
                     "health_check_grace_period_seconds": args.inputs.get("healthCheckGracePeriodSeconds"),
                 }
             if args.typ == "aws:rds/cluster:Cluster":

--- a/deployment/src/tests/test_container.py
+++ b/deployment/src/tests/test_container.py
@@ -184,6 +184,10 @@ def describe_container():
             assert sut.execution_role
 
         @pulumi.runtime.test
+        def it_enables_enable_execute_command(sut):
+            return assert_output_equals(sut.fargate_service.enable_execute_command, True)
+
+        @pulumi.runtime.test
         def its_execution_role_has_an_arn(sut):
             return assert_output_equals(sut.execution_role.arn,
                                         "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy")


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-1703)

## Purpose 
So that we can SSH into the containers and run `rails c`

## Approach 
Turn on `enable_execute_command`

## Testing
Did this in [central](https://github.com/StrongMind/global-build/commit/5a19b4f2da7ec545f1d92a732d9dfa1fbac83e20) and set it up manually elsewhere.
