### PR TITLE
Adding option to bypass creation of dns record

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -433,15 +433,16 @@ class ContainerComponent(pulumi.ComponentResource):
         zone_id = self.kwargs.get('zone_id', 'b4b7fec0d0aacbd55c5a259d1e64fff5')
         lb_dns_name = self.kwargs.get('load_balancer_dns_name',
                                       self.load_balancer.load_balancer.dns_name)  # pragma: no cover
-        self.cname_record = Record(
-            'cname_record',
-            name=name,
-            type='CNAME',
-            zone_id=zone_id,
-            value=lb_dns_name,
-            ttl=1,
-            opts=pulumi.ResourceOptions(parent=self),
-        )
+        if self.kwargs.get('cname', True):
+            self.cname_record = Record(
+                'cname_record',
+                name=name,
+                type='CNAME',
+                zone_id=zone_id,
+                value=lb_dns_name,
+                ttl=1,
+                opts=pulumi.ResourceOptions(parent=self),
+            )
         pulumi.export("url", Output.concat("https://", full_name))
 
         self.cert = aws.acm.Certificate(
@@ -469,8 +470,7 @@ class ContainerComponent(pulumi.ComponentResource):
             zone_id=zone_id,
             value=resource_record_value,
             ttl=1,
-            opts=pulumi.ResourceOptions(parent=self, depends_on=[self.cert,
-                                                                 self.cname_record]),
+            opts=pulumi.ResourceOptions(parent=self, depends_on=[self.cert]),
         )
 
         self.cert_validation_cert = aws.acm.CertificateValidation(


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/DEVOPS-10427)

## Purpose 
Migrate repository-dashboard, and every rails app using global build, to strongmind-deployment.

## Approach 
We need to bypass the creation of the DNS record while we stand up side-by-side environments in order to more easily facilitate the migrations. 

## Testing
Implemented this change locally as we stood up the new repository-dashboard environment.
Ran tests locally. 

## Screenshots/Video
![image](https://github.com/StrongMind/public-reusable-workflows/assets/101292749/f8dfdbbc-0b31-43f4-b89c-c98c2bf3afae)

![image](https://github.com/StrongMind/public-reusable-workflows/assets/101292749/6585d25c-3fce-4074-a7e2-48e8059c3097)
