### PR TITLE
Resolve an error when creating an s3 bucket

### DIFF
--- a/deployment/src/strongmind_deployment/storage.py
+++ b/deployment/src/strongmind_deployment/storage.py
@@ -37,8 +37,12 @@ class StorageComponent(pulumi.ComponentResource):
 
         acl_opts = pulumi.ResourceOptions(
             depends_on=[self.bucket_ownership_controls, self.bucket_public_access_block])  # pragma: no cover
+        if kwargs.get('storage_private', True):
+            acl="private"
+        else:
+            acl="public-read"
         self.bucket_acl = aws.s3.BucketAclV2("bucket_acl",
                                              bucket=self.bucket.id,
-                                             acl="public-read",
+                                             acl=acl,
                                              opts=acl_opts
                                              )

--- a/deployment/src/strongmind_deployment/storage.py
+++ b/deployment/src/strongmind_deployment/storage.py
@@ -37,10 +37,10 @@ class StorageComponent(pulumi.ComponentResource):
 
         acl_opts = pulumi.ResourceOptions(
             depends_on=[self.bucket_ownership_controls, self.bucket_public_access_block])  # pragma: no cover
-        if kwargs.get('storage_private', True):
-            acl="private"
-        else:
+        if kwargs.get('storage_private') = False:
             acl="public-read"
+        else:
+            acl="private"
         self.bucket_acl = aws.s3.BucketAclV2("bucket_acl",
                                              bucket=self.bucket.id,
                                              acl=acl,


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/DEVOPS-10663)

## Purpose 
The creation of an s3 bucket should default to a private bucket. 
Currently, the self.bucket_acl tries to reset the bucket to public after the self.bucket_public_access_block sets it to private. 

## Approach 
Added an if condition to reset the acl based on storage_private kwarg. 

## Testing
Found the issue when migrating central to strongmind deployement and resolved it on stage using this fix.

## Screenshots/Video
![image](https://github.com/StrongMind/public-reusable-workflows/assets/101292749/4991f209-062b-45a5-921e-3360fc62dcee)
![image](https://github.com/StrongMind/public-reusable-workflows/assets/101292749/2e55be07-5ddb-4160-8c2e-487bc4008027)

