### PR TITLE
Adding option to set desired count and minumum autoscale instances of task definitions for web container and worker container.

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -31,6 +31,8 @@ class ContainerComponent(pulumi.ComponentResource):
         :key custom_health_check_path: The path to use for the health check. Defaults to `/up`.
         :max_number_of_instances: The maximum number of instances available in the scaling policy. This should be as low
         as possible and only used when the defaults are no longer providing sufficent scaling.
+        :min_number_of_instances: The minimum number of instances available in the scaling policy. This should be as low
+        as possible and only used when the defaults are no longer providing sufficent scaling.
         """
         super().__init__('strongmind:global_build:commons:container', name, None, opts)
 
@@ -59,6 +61,7 @@ class ContainerComponent(pulumi.ComponentResource):
         self.autoscaling_target = None
         self.autoscaling_out_policy = None
         self.max_capacity = kwargs.get('max_number_of_instances', 1)
+        self.min_capacity = kwargs.get('min_number_of_instances', 1)
 
         stack = pulumi.get_stack()
         project = pulumi.get_project()
@@ -272,7 +275,7 @@ class ContainerComponent(pulumi.ComponentResource):
         self.autoscaling_target = aws.appautoscaling.Target(
             "autoscaling_target",
             max_capacity=self.max_capacity,
-            min_capacity=1,
+            min_capacity=self.min_capacity,
             resource_id=f"service/{self.project_stack}/{self.project_stack}",
             scalable_dimension="ecs:service:DesiredCount",
             service_namespace="ecs",

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -52,6 +52,8 @@ class RailsComponent(pulumi.ComponentResource):
         :key db_username: The username for connecting to the app database. Defaults to project name and environment.
         :key autoscale: Whether to autoscale the web container. Defaults to True.
         :key db_engine_version: The version of the database engine. Defaults to 15.2.
+        :key desired_web_count: The number of instances of the web container to run. Defaults to 1.
+        :key desired_worker_count: The number of instances of the worker container to run. Defaults to 1.
         """
         super().__init__('strongmind:global_build:commons:rails', name, None, opts)
         self.container_security_groups = None
@@ -82,6 +84,8 @@ class RailsComponent(pulumi.ComponentResource):
         self.env_vars = self.kwargs.get('env_vars', {})
         self.autoscale = self.kwargs.get('autoscale', True)
         self.engine_version = self.kwargs.get('db_engine_version', '15.2')
+        self.desired_web_count = self.kwargs.get('desired_web_count', 1)
+        self.desired_worker_count = self.kwargs.get('desired_worker_count', 1)
 
         self.env_name = os.environ.get('ENVIRONMENT_NAME', 'stage')
 
@@ -218,6 +222,7 @@ class RailsComponent(pulumi.ComponentResource):
         self.kwargs['secrets'] = self.secret.get_secrets()  # pragma: no cover
         self.kwargs['entry_point'] = web_entry_point
         self.kwargs['command'] = web_command
+        self.kwargs['desired_count'] = self.desired_web_count
         self.web_container = ContainerComponent("container",
                                                 pulumi.ResourceOptions(parent=self,
                                                                        depends_on=[self.execution]
@@ -249,6 +254,8 @@ class RailsComponent(pulumi.ComponentResource):
         self.kwargs['need_load_balancer'] = False
         self.kwargs['secrets'] = self.secret.get_secrets()  # pragma: no cover
         self.kwargs['log_metric_filters'] = self.worker_log_metric_filters
+        self.kwargs['desired_count'] = self.desired_worker_count
+            
         self.worker_container = ContainerComponent("worker",
                                                    pulumi.ResourceOptions(parent=self,
                                                                           depends_on=[self.execution]


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/DEVOPS-11191)

## Purpose 
Configure strongmind deployments to accept desired count and minimum number of instances for the number of desired tasks in the web container and worker container

## Approach 
Added needed kwargs and modified methods to accept and/or override the default kwargs.

## Testing
Have not tested it yet. 
