### PR TITLE
Add tags to cluster instances

### DIFF
--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -324,6 +324,7 @@ class RailsComponent(pulumi.ComponentResource):
             engine_version=self.rds_serverless_cluster.engine_version,
             apply_immediately=True,
             publicly_accessible=True,
+            tags=self.tags,
             opts=pulumi.ResourceOptions(parent=self,
                                         depends_on=[self.rds_serverless_cluster],
                                         protect=True),


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/DEVOPS-11259)

## Purpose 
Add tags to RDS DBInstances b/c repo-dashboard is replacing clusters with instances so we can pull in all instances, not just clustered ones. 

## Approach 
Add tags.tags to self.rds_serverless_cluster_instance

## Testing
Will verify with a deploy of repository-dashboard

## Screenshots/Video
![image](https://github.com/StrongMind/public-reusable-workflows/assets/101292749/c58e868d-00d2-4851-9c81-441a382956a3)
![image](https://github.com/StrongMind/public-reusable-workflows/assets/101292749/97ebb0c0-8945-4f62-bf44-3922ce29fd32)

