### PR TITLE
remove the default target group port from load balancer which was setting the port to 3000

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -385,7 +385,6 @@ class ContainerComponent(pulumi.ComponentResource):
         self.load_balancer = awsx.lb.ApplicationLoadBalancer(
             "loadbalancer",
             name=project_stack,
-            default_target_group_port=self.container_port,
             tags=self.tags,
             opts=pulumi.ResourceOptions(parent=self),
         )


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/DEVOPS-11329)

## Purpose 
Strongmind rails deployment should not setup port 3000 on the loadbalancer.

## Approach 
remove the default target group port from the load balancer setup

## Testing
Ran pytest and all tests passed
Will verify in prod with a deploy of repository-dashboard

## Screenshots/Video
![image](https://github.com/StrongMind/public-reusable-workflows/assets/101292749/cc146c82-9357-45b6-aa86-230dd849c6b8)

