### PR TITLE
Revert "remove the default target group port from load balancer which was setting the port to 3000"

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -385,6 +385,7 @@ class ContainerComponent(pulumi.ComponentResource):
         self.load_balancer = awsx.lb.ApplicationLoadBalancer(
             "loadbalancer",
             name=project_stack,
+            default_target_group_port=self.container_port,
             tags=self.tags,
             opts=pulumi.ResourceOptions(parent=self),
         )


### PR DESCRIPTION
Reverts StrongMind/public-reusable-workflows#71