### PR TITLE
creates iam policy and attaches to role; add tests

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -75,7 +75,7 @@ class ContainerComponent(pulumi.ComponentResource):
             "service": project,
             "environment": self.env_name,
         }
-
+        self.s3_policy_arn = self.env_vars.get('s3_policy_arn').apply(lambda arn: arn)
         self.ecs_cluster_arn = kwargs.get('ecs_cluster_arn')
         if self.ecs_cluster_arn is None:
             self.ecs_cluster = aws.ecs.Cluster("cluster",
@@ -221,6 +221,12 @@ class ContainerComponent(pulumi.ComponentResource):
             opts=pulumi.ResourceOptions(parent=self),
         )
 
+        self.s3_policy_attachement = aws.iam.RolePolicyAttachment(
+            f"{self.project_stack}-s3PolicyAttachment",
+            role=self.task_role.id,
+            policy_arn=self.s3_policy_arn.apply(lambda arn: arn)
+        )
+        
         self.task_definition_args = awsx.ecs.FargateServiceTaskDefinitionArgs(
             execution_role=DefaultRoleWithPolicyArgs(role_arn=self.execution_role.arn),
             task_role=DefaultRoleWithPolicyArgs(role_arn=self.task_role.arn),

--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -75,7 +75,6 @@ class ContainerComponent(pulumi.ComponentResource):
             "service": project,
             "environment": self.env_name,
         }
-        self.s3_policy_arn = self.env_vars.get('s3_policy_arn').apply(lambda arn: arn)
         self.ecs_cluster_arn = kwargs.get('ecs_cluster_arn')
         if self.ecs_cluster_arn is None:
             self.ecs_cluster = aws.ecs.Cluster("cluster",
@@ -221,12 +220,31 @@ class ContainerComponent(pulumi.ComponentResource):
             opts=pulumi.ResourceOptions(parent=self),
         )
 
-        self.s3_policy_attachement = aws.iam.RolePolicyAttachment(
-            f"{self.project_stack}-s3PolicyAttachment",
-            role=self.task_role.id,
-            policy_arn=self.s3_policy_arn.apply(lambda arn: arn)
-        )
-        
+        if self.kwargs.get('storage', False):
+            self.s3_policy = aws.iam.Policy(
+                f"{self.project_stack}-s3-policy",
+                name=f"{self.project_stack}-s3Policy",
+                policy=json.dumps({
+                    "Version": "2012-10-17",
+                    "Statement": [{
+                        "Effect": "Allow",
+                        "Action": [
+                            "s3:GetObject",
+                            "s3:PutObject",
+                            "s3:DeleteObject"
+                        ],
+                        "Resource": "*"
+                    }]
+                }),
+                tags=self.tags
+                )
+
+            self.s3_policy_attachement = aws.iam.RolePolicyAttachment(
+                f"{self.project_stack}-s3PolicyAttachment",
+                role=self.task_role.id,
+                policy_arn=self.s3_policy.arn,
+            )  
+
         self.task_definition_args = awsx.ecs.FargateServiceTaskDefinitionArgs(
             execution_role=DefaultRoleWithPolicyArgs(role_arn=self.execution_role.arn),
             task_role=DefaultRoleWithPolicyArgs(role_arn=self.task_role.arn),

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -224,6 +224,9 @@ class RailsComponent(pulumi.ComponentResource):
         self.kwargs['entry_point'] = web_entry_point
         self.kwargs['command'] = web_command
         self.kwargs['desired_count'] = self.desired_web_count
+        if self.kwargs.get('storage', False):
+            self.setup_storage()
+            self.kwargs['env_vars'].update(self.storage.s3_env_vars)
         self.web_container = ContainerComponent("container",
                                                 pulumi.ResourceOptions(parent=self,
                                                                        depends_on=[self.execution]
@@ -239,8 +242,6 @@ class RailsComponent(pulumi.ComponentResource):
         if self.need_worker:
             self.setup_worker()
 
-        if self.kwargs.get('storage', False):
-            self.setup_storage()
 
     def setup_worker(self):  # , execution):
         worker_cmd = self.kwargs.get('worker_cmd', ["sh", "-c", "bundle exec sidekiq"])
@@ -351,4 +352,4 @@ class RailsComponent(pulumi.ComponentResource):
                                         pulumi.ResourceOptions(parent=self),
                                         **self.kwargs
                                         )
-        self.env_vars['S3_BUCKET_NAME'] = self.storage.bucket.bucket
+        self.env_vars.update(self.storage.s3_env_vars)

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -191,6 +191,10 @@ class RailsComponent(pulumi.ComponentResource):
                                          "echo 'Migrations complete'"])
         self.kwargs['command'] = execution_cmd
 
+        if self.kwargs.get('storage', False):
+            self.setup_storage()
+            self.kwargs['env_vars'].update(self.storage.s3_env_vars)
+
         self.migration_container = ContainerComponent(
             "migration",
             need_load_balancer=False,
@@ -224,9 +228,7 @@ class RailsComponent(pulumi.ComponentResource):
         self.kwargs['entry_point'] = web_entry_point
         self.kwargs['command'] = web_command
         self.kwargs['desired_count'] = self.desired_web_count
-        if self.kwargs.get('storage', False):
-            self.setup_storage()
-            self.kwargs['env_vars'].update(self.storage.s3_env_vars)
+        
         self.web_container = ContainerComponent("container",
                                                 pulumi.ResourceOptions(parent=self,
                                                                        depends_on=[self.execution]

--- a/deployment/src/strongmind_deployment/storage.py
+++ b/deployment/src/strongmind_deployment/storage.py
@@ -47,24 +47,6 @@ class StorageComponent(pulumi.ComponentResource):
                                              opts=acl_opts
                                              )
 
-        self.s3_policy = aws.iam.Policy("s3Policy",
-            name=f"{project}-{stack}-s3Policy",
-            policy=json.dumps({
-                "Version": "2012-10-17",
-                "Statement": [{
-                    "Effect": "Allow",
-                    "Action": [
-                        "s3:GetObject",
-                        "s3:PutObject",
-                        "s3:DeleteObject"
-                    ],
-                    "Resource": "*"
-                }]
-            }),
-            tags=tags
-            )
-
         self.s3_env_vars = {
             "S3_BUCKET_NAME": self.bucket.bucket,
-            "s3_policy_arn": self.s3_policy.arn.apply(lambda arn: arn),
         }

--- a/deployment/src/strongmind_deployment/storage.py
+++ b/deployment/src/strongmind_deployment/storage.py
@@ -58,7 +58,7 @@ class StorageComponent(pulumi.ComponentResource):
                         "s3:PutObject",
                         "s3:DeleteObject"
                     ],
-                    "Resource": [f"arn:aws:s3:::{self.bucket.bucket}/*"]
+                    "Resource": "*"
                 }]
             }),
             tags=tags

--- a/deployment/src/strongmind_deployment/storage.py
+++ b/deployment/src/strongmind_deployment/storage.py
@@ -46,7 +46,7 @@ class StorageComponent(pulumi.ComponentResource):
                                              acl=acl,
                                              opts=acl_opts
                                              )
-        self.s3_user = aws.iam.User("s3User", name=f"{project}-{stack}-s3User-", tags=tags)
+
         self.s3_policy = aws.iam.Policy("s3Policy",
             name=f"{project}-{stack}-s3Policy",
             policy=json.dumps({
@@ -63,13 +63,8 @@ class StorageComponent(pulumi.ComponentResource):
             }),
             tags=tags
             )
-        aws.iam.UserPolicyAttachment("railsAppUserPolicyAttachment",
-            user=self.s3_user.name,
-            policy_arn=self.s3_policy.arn)
-        self.s3_user_secret_access_key = aws.iam.AccessKey("railsAppUserAccessKey", user=self.s3_user.name)
-        self.s3_user_access_key_id = self.s3_user_secret_access_key.id
+
         self.s3_env_vars = {
             "S3_BUCKET_NAME": self.bucket.bucket,
-            "AWS_ACCESS_KEY_ID": self.s3_user_access_key_id,
-            "AWS_SECRET_ACCESS_KEY": self.s3_user_secret_access_key.secret
+            "s3_policy_arn": self.s3_policy.arn.apply(lambda arn: arn),
         }

--- a/deployment/src/tests/test_rails.py
+++ b/deployment/src/tests/test_rails.py
@@ -819,3 +819,12 @@ def describe_a_pulumi_rails_component():
         @pulumi.runtime.test
         def it_sends_the_bucket_name_to_the_ecs_environment(sut):
             return assert_outputs_equal(sut.env_vars["S3_BUCKET_NAME"], sut.storage.bucket.bucket)
+        
+        @pulumi.runtime.test
+        def it_sends_the_access_key_id_to_the_ecs_environment(sut):
+            return assert_outputs_equal(sut.env_vars["AWS_ACCESS_KEY_ID"], sut.storage.s3_user_access_key_id)    
+        
+        @pulumi.runtime.test
+        def it_sends_the_secret_access_key_to_the_ecs_environment(sut):
+            return assert_outputs_equal(sut.env_vars["AWS_SECRET_ACCESS_KEY"], sut.storage.s3_user_secret_access_key.secret)
+        

--- a/deployment/src/tests/test_rails.py
+++ b/deployment/src/tests/test_rails.py
@@ -819,7 +819,3 @@ def describe_a_pulumi_rails_component():
         @pulumi.runtime.test
         def it_sends_the_bucket_name_to_the_ecs_environment(sut):
             return assert_outputs_equal(sut.env_vars["S3_BUCKET_NAME"], sut.storage.bucket.bucket)
-        
-        @pulumi.runtime.test
-        def it_sends_the_bucket_policy_arn_to_the_ecs_environment(sut):
-            return assert_outputs_equal(sut.env_vars["s3_policy_arn"], sut.storage.s3_policy.arn)

--- a/deployment/src/tests/test_rails.py
+++ b/deployment/src/tests/test_rails.py
@@ -821,10 +821,5 @@ def describe_a_pulumi_rails_component():
             return assert_outputs_equal(sut.env_vars["S3_BUCKET_NAME"], sut.storage.bucket.bucket)
         
         @pulumi.runtime.test
-        def it_sends_the_access_key_id_to_the_ecs_environment(sut):
-            return assert_outputs_equal(sut.env_vars["AWS_ACCESS_KEY_ID"], sut.storage.s3_user_access_key_id)    
-        
-        @pulumi.runtime.test
-        def it_sends_the_secret_access_key_to_the_ecs_environment(sut):
-            return assert_outputs_equal(sut.env_vars["AWS_SECRET_ACCESS_KEY"], sut.storage.s3_user_secret_access_key.secret)
-        
+        def it_sends_the_bucket_policy_arn_to_the_ecs_environment(sut):
+            return assert_outputs_equal(sut.env_vars["s3_policy_arn"], sut.storage.s3_policy.arn)

--- a/deployment/src/tests/test_storage.py
+++ b/deployment/src/tests/test_storage.py
@@ -121,6 +121,19 @@ def describe_a_pulumi_storage_component():
         @pulumi.runtime.test
         def it_is_an_aws_iam_user(sut):
             assert isinstance(sut.s3_user, pulumi_aws.iam.User)
+
+        @pulumi.runtime.test
+        def it_has_a_name(sut, app_name, stack):
+            return assert_output_equals(sut.s3_user.name, f"{app_name}-{stack}-s3User-")
+        
+        @pulumi.runtime.test
+        def it_has_tags(sut, app_name):
+            return assert_output_equals(sut.s3_user.tags, {
+                "product": app_name,
+                "repository": app_name,
+                "service": app_name,
+                "environment": sut.env_name,
+            })
         
     def describe_s3_policy():
         def it_has_a_policy(sut):
@@ -140,6 +153,19 @@ def describe_a_pulumi_storage_component():
                     "Resource": [f"arn:aws:s3:::{sut.bucket.bucket}/*"]
                 }]
             }))
+        
+        @pulumi.runtime.test
+        def it_has_a_name(sut, app_name, stack):
+            return assert_output_equals(sut.s3_policy.name, f"{app_name}-{stack}-s3Policy")
+        
+        @pulumi.runtime.test
+        def it_has_tags(sut, app_name):
+            return assert_output_equals(sut.s3_policy.tags, {
+                "product": app_name,
+                "repository": app_name,
+                "service": app_name,
+                "environment": sut.env_name,
+            })
 
 
     def describe_s3_access_key():

--- a/deployment/src/tests/test_storage.py
+++ b/deployment/src/tests/test_storage.py
@@ -114,30 +114,9 @@ def describe_a_pulumi_storage_component():
         def it_has_private_access(sut):
             return assert_output_equals(sut.bucket_acl.acl, "private")
         
-    def describe_s3_user():
-        def it_has_a_user(sut):
-            assert sut.s3_user
-
-        @pulumi.runtime.test
-        def it_is_an_aws_iam_user(sut):
-            assert isinstance(sut.s3_user, pulumi_aws.iam.User)
-
-        @pulumi.runtime.test
-        def it_has_a_name(sut, app_name, stack):
-            return assert_output_equals(sut.s3_user.name, f"{app_name}-{stack}-s3User-")
-        
-        @pulumi.runtime.test
-        def it_has_tags(sut, app_name):
-            return assert_output_equals(sut.s3_user.tags, {
-                "product": app_name,
-                "repository": app_name,
-                "service": app_name,
-                "environment": sut.env_name,
-            })
-        
     def describe_s3_policy():
         def it_has_a_policy(sut):
-            assert isinstance(sut.s3_policy, pulumi_aws.iam.Policy)
+            assert isinstance(sut.s3_policy, pulumi_aws.iam.RolePolicy)
         
         @pulumi.runtime.test
         def it_has_a_policy_document(sut):
@@ -159,23 +138,18 @@ def describe_a_pulumi_storage_component():
             return assert_output_equals(sut.s3_policy.name, f"{app_name}-{stack}-s3Policy")
         
         @pulumi.runtime.test
-        def it_has_tags(sut, app_name):
-            return assert_output_equals(sut.s3_policy.tags, {
-                "product": app_name,
-                "repository": app_name,
-                "service": app_name,
-                "environment": sut.env_name,
-            })
+        def it_has_a_role(sut):
+            return assert_output_equals(sut.s3_policy.role, sut.task_role.id)
 
-
-    def describe_s3_access_key():
-        def it_has_an_access_key(sut):
-            assert sut.s3_user_secret_access_key
-        
-        def it_is_an_aws_iam_access_key(sut):
-            assert isinstance(sut.s3_user_secret_access_key, pulumi_aws.iam.AccessKey)
+    def describe_s3_env_vars():
+        def it_has_env_vars(sut):
+            assert sut.s3_env_vars
 
         @pulumi.runtime.test
-        def it_has_a_user(sut):
-            return assert_outputs_equal(sut.s3_user_secret_access_key.user, sut.s3_user.name)
+        def it_has_a_bucket_name(sut):
+            return assert_output_equals(sut.s3_env_vars["S3_BUCKET_NAME"], sut.bucket.bucket)
+
+        @pulumi.runtime.test
+        def it_has_a_policy_arn(sut):
+            return assert_output_equals(sut.s3_env_vars["s3_policy_arn"], sut.s3_policy.arn.apply(lambda arn: arn))
         

--- a/deployment/src/tests/test_storage.py
+++ b/deployment/src/tests/test_storage.py
@@ -113,43 +113,13 @@ def describe_a_pulumi_storage_component():
         @pulumi.runtime.test
         def it_has_private_access(sut):
             return assert_output_equals(sut.bucket_acl.acl, "private")
-        
-    def describe_s3_policy():
-        def it_has_a_policy(sut):
-            assert isinstance(sut.s3_policy, pulumi_aws.iam.RolePolicy)
-        
-        @pulumi.runtime.test
-        def it_has_a_policy_document(sut):
-            return assert_output_equals(sut.s3_policy.policy, json.dumps({
-                "Version": "2012-10-17",
-                "Statement": [{
-                    "Effect": "Allow",
-                    "Action": [
-                        "s3:GetObject",
-                        "s3:PutObject",
-                        "s3:DeleteObject"
-                    ],
-                    "Resource": [f"arn:aws:s3:::{sut.bucket.bucket}/*"]
-                }]
-            }))
-        
-        @pulumi.runtime.test
-        def it_has_a_name(sut, app_name, stack):
-            return assert_output_equals(sut.s3_policy.name, f"{app_name}-{stack}-s3Policy")
-        
-        @pulumi.runtime.test
-        def it_has_a_role(sut):
-            return assert_output_equals(sut.s3_policy.role, sut.task_role.id)
-
+    
     def describe_s3_env_vars():
         def it_has_env_vars(sut):
             assert sut.s3_env_vars
 
         @pulumi.runtime.test
-        def it_has_a_bucket_name(sut):
-            return assert_output_equals(sut.s3_env_vars["S3_BUCKET_NAME"], sut.bucket.bucket)
+        def it_sends_the_bucket_name_to_the_ecs_environment(sut):
+            return sut.bucket.bucket.apply(lambda bucket: assert_outputs_equal(sut.s3_env_vars["S3_BUCKET_NAME"], bucket))
 
-        @pulumi.runtime.test
-        def it_has_a_policy_arn(sut):
-            return assert_output_equals(sut.s3_env_vars["s3_policy_arn"], sut.s3_policy.arn.apply(lambda arn: arn))
         


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/DEVOPS-11255)

## Purpose 
For RailsComponent with storage=True, setup AWS credentials

## Approach 
Create Iam policy for s3
Attach policy to task role


## Testing
Added tests for storage, container, and rails changes.
Verified with good pulumi up.
Verified can still access s3 bucket w/o needing access key or id provided in storage yaml.

## Screenshots/Video
![image](https://github.com/StrongMind/public-reusable-workflows/assets/101292749/53a0309e-1947-47d1-9b00-15d8fe42326a)
![image](https://github.com/StrongMind/public-reusable-workflows/assets/101292749/1d89bcb5-fe92-4945-b8ca-9f2548084e92)
