### PR TITLE
(B) PLT-9553: Modify container scale in/out cooldowns

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -313,7 +313,7 @@ class ContainerComponent(pulumi.ComponentResource):
             service_namespace=self.autoscaling_target.service_namespace,
             step_scaling_policy_configuration=aws.appautoscaling.PolicyStepScalingPolicyConfigurationArgs(
                 adjustment_type="ChangeInCapacity",
-                cooldown=60,
+                cooldown=15,
                 metric_aggregation_type="Maximum",
                 step_adjustments=[
                     aws.appautoscaling.PolicyStepScalingPolicyConfigurationStepAdjustmentArgs(
@@ -354,7 +354,7 @@ class ContainerComponent(pulumi.ComponentResource):
             service_namespace=self.autoscaling_target.service_namespace,
             step_scaling_policy_configuration=aws.appautoscaling.PolicyStepScalingPolicyConfigurationArgs(
                 adjustment_type="ChangeInCapacity",
-                cooldown=60,
+                cooldown=900,
                 metric_aggregation_type="Maximum",
                 step_adjustments=[
                     aws.appautoscaling.PolicyStepScalingPolicyConfigurationStepAdjustmentArgs(

--- a/deployment/src/tests/test_container_autoscaling.py
+++ b/deployment/src/tests/test_container_autoscaling.py
@@ -185,7 +185,7 @@ def describe_autoscaling():
 
             @pulumi.runtime.test
             def it_has_a_default_cooldown(sut):
-                return assert_output_equals(sut.autoscaling_in_policy.step_scaling_policy_configuration.cooldown, 60)
+                return assert_output_equals(sut.autoscaling_in_policy.step_scaling_policy_configuration.cooldown, 900)
 
             @pulumi.runtime.test
             def it_changes_capacity(sut):
@@ -251,7 +251,7 @@ def describe_autoscaling():
 
             @pulumi.runtime.test
             def it_has_a_default_cooldown(sut):
-                return assert_output_equals(sut.autoscaling_out_policy.step_scaling_policy_configuration.cooldown, 60)
+                return assert_output_equals(sut.autoscaling_out_policy.step_scaling_policy_configuration.cooldown, 15)
 
             @pulumi.runtime.test
             def it_changes_capacity(sut):


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/PLT-9553)

## Purpose 
So that containers will scale up quicker, and stay around longer during peridos of heavy load in an effort to reduce 5XX errors.

## Approach 
Decrease scale out cooldown to 15 seconds (from 60) Increase scale in cooldown to 900 seconds (from 60)

## Testing
unit tests

## Screenshots/Video
N/A
