### PR TITLE
Feature/caylent main pre release version

### DIFF
--- a/deployment/pyproject.toml
+++ b/deployment/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "strongmind_deployment"
-version = "0.0.1"
+version = "2.0.0-dev"
 
 authors = [
   { name="Belding", email="teambelding@strongmind.com" },


### PR DESCRIPTION
Require hard coding a version it the pyproject.toml file so this can be a dependency in pip, otherwise it fails to install with the unknown package version env var. 