### PR TITLE
deploy strongmind beta

### DIFF
--- a/.github/workflows/build-deployment-package.yml
+++ b/.github/workflows/build-deployment-package.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - caylent_main
     paths:
       - 'deployment/**'
 

--- a/deployment/pyproject.toml
+++ b/deployment/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "strongmind_deployment"
+name = "strongmind_deployment_beta"
 version = "2.0.0-dev"
 
 authors = [


### PR DESCRIPTION
## Purpose
We have been having issues sourcing this repo in pulumi projects as a git dependency.   Pulumi tries cloning and explodes in doing so. 

It works ok for development, but not in github actions. 

Example: 

https://github.com/StrongMind/shared-infrastructure/actions/runs/8328969113/job/22790798781

## How

trigger python package builds off the `caylent_main` branch, and send them to a new pypi project `strongmind_deployments_beta`. 

