### PR TITLE
Fix/beta release

### DIFF
--- a/.github/workflows/python-package-build.yml
+++ b/.github/workflows/python-package-build.yml
@@ -28,8 +28,9 @@ jobs:
         make test
 
     - name: package files
+    # major version changed during the Azure migration engagement with Caylent.
       run: |
-        make build -e VERSION=1.1.${{ github.run_number }}
+        make build -e VERSION=2.0.${{ github.run_number }}
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v3

--- a/deployment/pyproject.toml
+++ b/deployment/pyproject.toml
@@ -27,3 +27,7 @@ dependencies = [
 
 [project.urls]
 "Homepage" = "https://github.com/strongmind/public-reusable-workflows/tree/main/deployment"
+
+# optional: only required for beta release.
+[tool.hatch.build.targets.wheel]
+packages = ["deployment/strongmind_deployment"]


### PR DESCRIPTION
This should fix the beta deployment. 

The previous run failed indicating `strongmind_deployment_beta` did not match the directory name.

This change of package name requires a hatchling configuration change. 

Changes included: 
* hatchling config fix
* version fix - targeting 2.0.x  for this new beta package. 

## local test
![image](https://github.com/StrongMind/public-reusable-workflows/assets/723989/748a1dc6-49ce-4dbc-86e1-5b2368605feb)
