### PR TITLE
Alarm when ecs healthy host count is less than desired host count.

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -413,6 +413,26 @@ class ContainerComponent(pulumi.ComponentResource):
             tags=self.tags,
             opts=pulumi.ResourceOptions(parent=self),
         )
+        sns_topic_arn = kwargs.get('sns_topic_arn', 'arn:aws:sns:us-west-2:221871915463:DevOps-Opsgenie')
+        self.healthy_host_metric_alarm = aws.cloudwatch.MetricAlarm(
+            "healthy_host_metric_alarm",
+            name=f"{project_stack}-healthy-host-metric-alarm",
+            comparison_operator="LessThanThreshold",
+            datapoints_to_alarm=1,
+            dimensions={
+                "LoadBalancer": self.load_balancer.load_balancer.name,
+                "TargetGroup": self.target_group.name,
+            },
+            evaluation_periods=1,
+            metric_name="HealthyHostCount",
+            namespace="AWS/ApplicationELB",
+            ok_actions=[sns_topic_arn],
+            period=60,
+            statistic="Maximum",
+            threshold="1",
+            treat_missing_data="notBreaching",
+        )
+
         self.dns(project, stack)
         load_balancer_arn = kwargs.get('load_balancer_arn', self.load_balancer.load_balancer.arn)
         target_group_arn = kwargs.get('target_group_arn', self.target_group.arn)


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/devops-13588)

## Purpose 
<!-- what/why -->
Alarm when ecs healthy host count is less than desired host count.
## Approach 
<!-- how -->
Added a metric alarm to the load balancer for container.py
Added desired_web_count as the threshold minimum metric
Added sns_topic_arn for the actions.
Currently hardcoded devops-opsgenie sns; we have a future story to make this dynamic based on owning team tag
## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Ran with pulumi locally and verified metric alarm created 
## Screenshots/Video
<!-- show before/after of the change if possible -->
![image](https://github.com/StrongMind/public-reusable-workflows/assets/101292749/600ba904-0701-4f0b-bf21-2f97b2560afe)
