### PR TITLE
Refactor healthy_host_metric_alarm creation in ContainerComponent

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -429,8 +429,8 @@ class ContainerComponent(pulumi.ComponentResource):
                 comparison_operator="LessThanThreshold",
                 datapoints_to_alarm=1,
                 dimensions={
-                    "LoadBalancer":f"app/{project_stack}/{args[0]}",
-                    "TargetGroup":f"targetgroup/{project_stack}/{args[1]}",
+                    "LoadBalancer":f"app/{project_stack}/{load_balancer_dimension}",
+                    "TargetGroup":f"targetgroup/{project_stack}/{target_group_dimension}",
                 },
                 evaluation_periods=1,
                 metric_name="HealthyHostCount",

--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -416,25 +416,33 @@ class ContainerComponent(pulumi.ComponentResource):
             tags=self.tags,
             opts=pulumi.ResourceOptions(parent=self),
         )
-        self.healthy_host_metric_alarm = aws.cloudwatch.MetricAlarm(
-            "healthy_host_metric_alarm",
-            name=f"{project_stack}-healthy-host-metric-alarm",
-            comparison_operator="LessThanThreshold",
-            datapoints_to_alarm=1,
-            dimensions={
-                "LoadBalancer": self.load_balancer.load_balancer.name,
-                "TargetGroup": self.target_group.name,
-            },
-            evaluation_periods=1,
-            metric_name="HealthyHostCount",
-            namespace="AWS/ApplicationELB",
-            alarm_actions=[self.sns_topic_arn],
-            ok_actions=[self.sns_topic_arn],
-            period=60,
-            statistic="Maximum",
-            threshold=self.desired_web_count,
-            treat_missing_data="notBreaching",
-            tags=self.tags,
+        load_balancer_dimension = self.load_balancer.load_balancer.arn.apply(
+            lambda arn: arn.split("/")[-1]
+        )
+        target_group_dimension = self.target_group.arn.apply(
+            lambda arn: arn.split("/")[-1]
+        )
+        self.healthy_host_metric_alarm = pulumi.Output.all(load_balancer_dimension, target_group_dimension).apply(lambda args: 
+            aws.cloudwatch.MetricAlarm(
+                "healthy_host_metric_alarm",
+                name=f"{project_stack}-healthy-host-metric-alarm",
+                comparison_operator="LessThanThreshold",
+                datapoints_to_alarm=1,
+                dimensions={
+                    "LoadBalancer":f"app/{project_stack}/{args[0]}",
+                    "TargetGroup":f"targetgroup/{project_stack}/{args[1]}",
+                },
+                evaluation_periods=1,
+                metric_name="HealthyHostCount",
+                namespace="AWS/ApplicationELB",
+                alarm_actions=[self.sns_topic_arn],
+                ok_actions=[self.sns_topic_arn],
+                period=60,
+                statistic="Maximum",
+                threshold=self.desired_web_count,
+                treat_missing_data="notBreaching",
+                tags=self.tags,
+            )
         )
 
         self.dns(project, stack)


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/devops-13588)

## Purpose 
<!-- what/why -->
Refactor healthy_host_metric_alarm creation in ContainerComponent so that current tests will pass; also use the right dimensions for the LB and TG
## Approach 
<!-- how -->
Refactored the healthy_host_metric_alarm to use lambda apply for LB and TG arns
## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Ran pulumi up locally and verified alarm created with corrected dimensions
Tests pass although still seeing this: AttributeError: 'NoneType' object has no attribute 'arn'
Still need to create test for this method, expecting tests to pass in workflow, pushing this as main workflow is broken.
Will create backlog item to add test for this method. 
## Screenshots/Video
<!-- show before/after of the change if possible -->
![image](https://github.com/StrongMind/public-reusable-workflows/assets/101292749/b2e5617c-bc29-4ee4-ab97-db10f77f30eb)
![image](https://github.com/StrongMind/public-reusable-workflows/assets/101292749/768f0ada-4b33-4758-8ae0-74ab8c6568b0)
![image](https://github.com/StrongMind/public-reusable-workflows/assets/101292749/096f6de0-0fe5-4f4c-bd00-635eed18e4a5)
