### PR TITLE
Use positional args in the healthy_host_metric_alarm instead of keyword args

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -429,8 +429,8 @@ class ContainerComponent(pulumi.ComponentResource):
                 comparison_operator="LessThanThreshold",
                 datapoints_to_alarm=1,
                 dimensions={
-                    "LoadBalancer":f"app/{project_stack}/{load_balancer_dimension}",
-                    "TargetGroup":f"targetgroup/{project_stack}/{target_group_dimension}",
+                    "LoadBalancer":f"app/{project_stack}/{args[0]}",
+                    "TargetGroup":f"targetgroup/{project_stack}/{args[1]}",
                 },
                 evaluation_periods=1,
                 metric_name="HealthyHostCount",


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/devios-13588)

## Purpose 
<!-- what/why -->
Use positional args in the metric_alarm instead of promised values
## Approach 
<!-- how -->
Use positional args in the metric_alarm instead of promised values to allow for 'lazily' applied output
## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Verified locally with repo dashboard
## Screenshots/Video
<!-- show before/after of the change if possible -->
