### PR TITLE
Feature/excay2 36 vpc component no awsx

### DIFF
--- a/deployment/src/strongmind_deployment/subnet.py
+++ b/deployment/src/strongmind_deployment/subnet.py
@@ -1,0 +1,109 @@
+
+from enum import Enum
+from typing import List
+class SubnetType(str, Enum): 
+    """
+    A type of subnet within a VPC.
+    """
+
+    PUBLIC = "Public"
+    """
+    A subnet whose hosts can directly communicate with the internet.
+    """
+    PRIVATE = "Private"
+    """
+    A subnet whose hosts can not directly communicate with the internet, but can initiate outbound network traffic via a NAT Gateway.
+    """
+    ISOLATED = "Isolated"
+    """
+    A subnet whose hosts have no connectivity with the internet.
+    """
+    UNUSED = "Unused"
+    """
+    A subnet range which is reserved, but no subnet will be created.
+    """
+
+
+class SubnetSpec:
+    def __init__(self, type: SubnetType,  cidr_blocks: List[str]) -> None:
+        self.type = type
+        self.cidr_blocks = cidr_blocks
+    
+    @staticmethod
+    def get_subnet_by_type(specs: 'List[SubnetSpec]', type: SubnetType):
+        """
+        Get the subnet spec with the specified type from the list of subnet specs.
+        """
+        for spec in specs:
+            if spec.type == type:
+                return spec
+        return None
+
+    @staticmethod
+    def trim_cidr_block_to_prefix(cidr_block: str) -> str:
+        """
+        Trims the CIDR block to the specified prefix.
+        """
+        return ".".join(cidr_block.split(".")[:2])
+
+    @staticmethod
+    def get_standard_subnet_specs(cidr_block: str)-> 'List[SubnetSpec]':
+        """
+        Returns a standard allocation of subnets for a /16 VPC CIDR block.
+        This requires 3 AZ's be available.
+
+        The allocation is as follows:
+        - 3 public subnets - 1 per AZ, with a mask of /20
+        - 3 private subnets - 1 per AZ, with a mask of /19
+        - 3 isolated subnets - 1 per AZ, with a mask of /21
+        - 3 unused subnets - 1 per AZ, with a mask of /21
+            -> these unused subnets are purposely reserved for future use. It's not necessary
+               to identify them here, but we do so for clarity.
+        """
+
+        cidr_prefix = SubnetSpec.trim_cidr_block_to_prefix(cidr_block)
+        subnet_specs = [
+            SubnetSpec(
+                type=SubnetType.PRIVATE,
+                cidr_blocks=[
+                    f"{cidr_prefix}.0.0/19",
+                    f"{cidr_prefix}.64.0/19",
+                    f"{cidr_prefix}.128.0/19",
+                ],
+            ),
+            SubnetSpec(
+                type=SubnetType.PUBLIC,
+                cidr_blocks=[
+                    f"{cidr_prefix}.32.0/20",
+                    f"{cidr_prefix}.96.0/20",
+                    f"{cidr_prefix}.160.0/20",
+                ],
+            ),
+            SubnetSpec(
+                type=SubnetType.ISOLATED,
+                cidr_blocks=[
+                    f"{cidr_prefix}.48.0/21",
+                    f"{cidr_prefix}.112.0/21",
+                    f"{cidr_prefix}.176.0/21",
+                ],
+            ),
+            # explicitly define remaining cidrs
+            SubnetSpec(
+                type=SubnetType.UNUSED,
+                cidr_blocks=[
+                    f"{cidr_prefix}.56.0/21",
+                    f"{cidr_prefix}.120.0/21",
+                    f"{cidr_prefix}.184.0/21",
+                ],
+            ),
+            SubnetSpec(
+                type=SubnetType.UNUSED,
+                cidr_blocks=[
+                    f"{cidr_prefix}.192.0/19",
+                    f"{cidr_prefix}.224.0/20",
+                    f"{cidr_prefix}.240.0/20",
+                ],
+            ),
+        ]
+
+        return subnet_specs

--- a/deployment/src/strongmind_deployment/vpc.py
+++ b/deployment/src/strongmind_deployment/vpc.py
@@ -1,116 +1,245 @@
-from typing import Optional
+from enum import Enum
 import pulumi
-import pulumi_awsx as awsx
-from pulumi_awsx.ec2 import SubnetSpecArgs
+import pulumi_aws as aws
+from typing import List, Optional
+from strongmind_deployment.subnet import SubnetSpec, SubnetType
+
+
+class NatGatewayStrategy(str, Enum):
+    SINGLE = "single"
+    ONE_PER_AZ = "one_per_az"
+    NONE = "none"
+
+    def __str__(self):
+        return self.value
+
 
 class VpcComponentArgs:
     def __init__(
         self,
-        vpc_name: str,
         cidr_block: str,
-        tags: Optional[dict] = None,
-        enable_nat_gateway: bool = False,
-    ) -> None:
-        self.vpc_name = vpc_name or f"{pulumi.get_project()}-{pulumi.get_stack()}"
+        nat_gateway_strategy: Optional[NatGatewayStrategy] = NatGatewayStrategy.SINGLE,
+    ):
         self.cidr_block = cidr_block
-        self.tags = tags
-        self.enable_nat_gateway = enable_nat_gateway
+        self.nat_gateway_strategy = nat_gateway_strategy
+
+
+class SubnetWithLocation:
+    def __init__(self, subnet: aws.ec2.Subnet, availability_zone: str):
+        self.subnet = subnet
+        self.availability_zone = availability_zone
+
 
 class VpcComponent(pulumi.ComponentResource):
-    def __init__(self, args: VpcComponentArgs) -> None:
-        self.args = args
+    public_subnets: List[aws.ec2.Subnet] = []
+    private_subnets: List[aws.ec2.Subnet] = []
+    database_subnets: List[aws.ec2.Subnet] = []
+
+    def __init__(self, name, args: VpcComponentArgs, opts=None):
+        super().__init__("strongmind:global_build:commons:vpc", name, {}, opts)
+        self.child_opts = pulumi.ResourceOptions(parent=self)
+        self.vpc_name = name
+        self.subnet_specs = SubnetSpec.get_standard_subnet_specs(args.cidr_block)
+        self.args: VpcComponentArgs = args
+        self.azs = aws.get_availability_zones(state="available").names[:3]
+        self.validate_args()
         self.create_resources()
 
-    @property
-    def id(self) -> str:
-        return self.vpc.vpc_id.apply(lambda id: id)
-
-    def create_resources(self) -> None:
-        self.vpc = self.create_vpc()
-
-    def get_vpc_cidr_prefix(self) -> str:
-        cidr_prefix = self.args.cidr_block.split(".")[:2]
-        return ".".join(cidr_prefix)
-
-    def create_vpc(self) -> awsx.ec2.Vpc:
-        nat_gateway_config = self.get_nat_gateway_config()
-
-        cidr_prefix = self.get_vpc_cidr_prefix()
-
-        subnet_specs = [
-            SubnetSpecArgs(
-                type=awsx.ec2.SubnetType.PRIVATE,
-                cidr_mask=19,
-                cidr_blocks=[
-                    f"{cidr_prefix}.0.0/19",
-                    f"{cidr_prefix}.64.0/19",
-                    f"{cidr_prefix}.128.0/19",
-                ],
-            ),
-            SubnetSpecArgs(
-                type=awsx.ec2.SubnetType.PUBLIC,
-                cidr_mask=20,
-                cidr_blocks=[
-                    f"{cidr_prefix}.32.0/20",
-                    f"{cidr_prefix}.96.0/20",
-                    f"{cidr_prefix}.160.0/20",
-                ],
-            ),
-            SubnetSpecArgs(
-                type=awsx.ec2.SubnetType.ISOLATED,
-                cidr_mask=21,
-                cidr_blocks=[
-                    f"{cidr_prefix}.48.0/21",
-                    f"{cidr_prefix}.112.0/21",
-                    f"{cidr_prefix}.176.0/21",
-                ],
-            ),
-            # must explicitly define remaining cidrs
-            SubnetSpecArgs(
-                type=awsx.ec2.SubnetType.UNUSED,
-                cidr_mask=21,
-                cidr_blocks=[
-                    f"{cidr_prefix}.56.0/21",
-                    f"{cidr_prefix}.120.0/21",
-                    f"{cidr_prefix}.184.0/21",
-                    # f"{cidr_prefix}.192.0/18",
-                ],
-            ),
-            SubnetSpecArgs(
-                type=awsx.ec2.SubnetType.UNUSED,
-                cidr_blocks=[
-                    f"{cidr_prefix}.192.0/19",
-                    f"{cidr_prefix}.224.0/20",
-                    f"{cidr_prefix}.240.0/20",
-                ],
-            ),
-        ]
-
-        vpc = awsx.ec2.Vpc(
-            f"{self.args.vpc_name}",
-            cidr_block=self.args.cidr_block,
-            number_of_availability_zones=3,
-            enable_dns_hostnames=True,
-            enable_dns_support=True,
-            nat_gateways=nat_gateway_config,
-            subnet_specs=subnet_specs,
-            subnet_strategy=awsx.ec2.SubnetAllocationStrategy.AUTO,
-            tags=self.args.tags,
-        )
-
-        return vpc
-
-    def get_nat_gateway_config(self) -> awsx.ec2.NatGatewayConfigurationArgs:
-        if not self.args.enable_nat_gateway:
-            return awsx.ec2.NatGatewayConfigurationArgs(
-                strategy=awsx.ec2.NatGatewayStrategy.NONE
+    def validate_args(self):
+        """
+        Basic validation to ensure we are setting things up correctly.
+        """
+        # ensure there are 3 AZ's
+        if len(self.azs) != 3:
+            raise ValueError(
+                "This module requires exactly 3 availability zones. The region you are deploying to does not have 3 AZ's available."
             )
 
-        # if the stack doesn't contain 'prod' then use a single NAT gateway
-        if "prod" in pulumi.get_stack():
-            strategy = awsx.ec2.NatGatewayStrategy.ONE_PER_AZ
-        else:
-            strategy = awsx.ec2.NatGatewayStrategy.SINGLE
+        # CIDR is required to be a /16
+        if not self.args.cidr_block.endswith("/16"):
+            raise ValueError("VPC CIDR must be a /16")
 
-        config_args = awsx.ec2.NatGatewayConfigurationArgs(strategy=strategy)
-        return config_args
+    def create_resources(self):
+        self.vpc = self.create_vpc()
+        self.gateway = self.create_internet_gateway()
+
+        self.public_subnets = self.create_public_subnets()
+        self.private_subnets = self.create_private_subnets()
+        self.database_subnets = self.create_database_subnets()
+
+    def create_vpc(self: pulumi.ComponentResource):
+        vpc_name = self.vpc_name
+
+        return aws.ec2.Vpc(
+            vpc_name,
+            cidr_block=self.args.cidr_block,
+            enable_dns_hostnames=True,
+            enable_dns_support=True,
+            tags={"Name": vpc_name},
+            opts=self.child_opts,
+        )
+
+    def create_internet_gateway(self) -> aws.ec2.InternetGateway:
+        return aws.ec2.InternetGateway(
+            f"{self.vpc_name}-igw",
+            vpc_id=self.vpc.id,
+            tags={"Name": f"{self.vpc_name}-gateway"},
+            opts=self.child_opts,
+        )
+
+    def should_create_nat_gateway(self, i: int) -> bool:
+        """
+        Expects the index of an iterator to determine if a NAT Gateway should be created.
+        """
+        if self.args.nat_gateway_strategy == NatGatewayStrategy.ONE_PER_AZ:
+            return True
+
+        return self.args.nat_gateway_strategy == NatGatewayStrategy.SINGLE and i == 0
+
+    def create_public_subnets(self):
+        public_subnets = []
+
+        public_subnet_spec = SubnetSpec.get_subnet_by_type(
+            self.subnet_specs, SubnetType.PUBLIC
+        )
+
+        subnet_azs = zip(public_subnet_spec.cidr_blocks, self.azs)
+
+        for cidr_block, az in subnet_azs:
+            public_subnet = aws.ec2.Subnet(
+                f"pub-subnet-{az}",
+                vpc_id=self.vpc.id,
+                cidr_block=cidr_block,
+                map_public_ip_on_launch=True,
+                availability_zone=az,
+                tags={
+                    "Name": f"{self.vpc_name}-public-subnet-{az}",
+                    "SubnetType": SubnetType.PUBLIC,
+                },
+                opts=self.child_opts,
+            )
+            public_route_table = aws.ec2.RouteTable(
+                f"pub-routeTable-{az}",
+                vpc_id=self.vpc.id,
+                routes=[
+                    aws.ec2.RouteTableRouteArgs(
+                        cidr_block="0.0.0.0/0", gateway_id=self.gateway.id
+                    ),
+                ],
+                tags={
+                    "Name": f"{self.vpc_name}-public-rt-{az}",
+                    "SubnetType": SubnetType.PUBLIC,
+                },
+                opts=self.child_opts,
+            )
+
+            aws.ec2.RouteTableAssociation(
+                f"pub-routeTableAssociation-{az}",
+                subnet_id=public_subnet.id,
+                route_table_id=public_route_table.id,
+                opts=self.child_opts,
+            )
+
+            public_subnets.append(public_subnet)
+            self.public_subnets = public_subnets
+
+    def create_private_subnets(self):
+        private_subnets = []
+        recently_created_nat_gateway: aws.ec2.NatGateway = None
+
+        private_subnet_spec = SubnetSpec.get_subnet_by_type(
+            self.subnet_specs, SubnetType.PRIVATE
+        )
+
+        subnet_azs = zip(private_subnet_spec.cidr_blocks, self.azs)
+
+        for i, (cidr_block, az) in enumerate(subnet_azs):
+            private_subnet = aws.ec2.Subnet(
+                f"pri-subnet-{az}",
+                vpc_id=self.vpc.id,
+                cidr_block=cidr_block,
+                map_public_ip_on_launch=False,
+                availability_zone=az,
+                tags={"Name": f"{self.vpc_name}-private-subnet-{az}"},
+                opts=self.child_opts,
+            )
+
+            if self.should_create_nat_gateway(i):
+                # If we are in a single nat gateawy scenario, only the first AZ will get one.
+                # However, this property will persist outside the for loop, and be assigned
+                # to other Subnets.
+                recently_created_nat_gateway = self.create_nat_gateway(
+                    az, private_subnet
+                )
+
+            if not self.args.nat_gateway_strategy == NatGatewayStrategy.NONE:
+                private_route_table = aws.ec2.RouteTable(
+                    f"pri-routeTable-{az}",
+                    vpc_id=self.vpc.id,
+                    routes=[
+                        aws.ec2.RouteTableRouteArgs(
+                            cidr_block="0.0.0.0/0",
+                            nat_gateway_id=recently_created_nat_gateway.id,
+                        ),
+                    ],
+                    tags={
+                        "Name": f"{self.vpc_name}-private-rt-{az}",
+                        "SubnetType": SubnetType.PRIVATE,
+                    },
+                    opts=self.child_opts,
+                )
+
+                aws.ec2.RouteTableAssociation(
+                    f"pri-routeTableAssociation-{az}",
+                    subnet_id=private_subnet.id,
+                    route_table_id=private_route_table.id,
+                    opts=self.child_opts,
+                )
+
+            private_subnets.append(private_subnet.id)
+        return private_subnets
+
+    def create_nat_gateway(self, az, private_subnet):
+        eip = aws.ec2.Eip(
+            f"{self.vpc_name}-eip-{az}",
+            tags={"Name": f"{self.vpc_name}-natgateway-eip-{az}"},
+            opts=self.child_opts,
+        )
+
+        nat_gateway = aws.ec2.NatGateway(
+            f"{self.vpc_name}-natGateway-{az}",
+            subnet_id=private_subnet.id,
+            allocation_id=eip.id,
+            tags={
+                "Name": f"{self.vpc_name}-nat-gateway-{az}",
+                "SubnetType": SubnetType.PRIVATE,
+            },
+            opts=self.child_opts,
+        )
+
+        return nat_gateway
+
+    def create_database_subnets(self):
+        database_subnets = []
+
+        public_subnet_spec = SubnetSpec.get_subnet_by_type(
+            self.subnet_specs, SubnetType.ISOLATED
+        )
+
+        subnet_azs = zip(public_subnet_spec.cidr_blocks, self.azs)
+
+        for cidr_block, az in subnet_azs:
+            database_subnet = aws.ec2.Subnet(
+                f"db-subnet-{az}",
+                vpc_id=self.vpc.id,
+                cidr_block=cidr_block,
+                map_public_ip_on_launch=False,
+                availability_zone=az,
+                tags={
+                    "Name": f"{self.vpc_name}-database-subnet-{az}",
+                    "SubnetType": SubnetType.ISOLATED,
+                },
+                opts=self.child_opts,
+            )
+            database_subnets.append(database_subnet.id)
+        return database_subnets


### PR DESCRIPTION
[EXCAY2-36](https://strongmind.atlassian.net/browse/EXCAY2-36)

## Purpose 
Replacing the existing VPC - as it uses Crosswalk which we are not interested in using.



## Testing
Unit tests are not present here.  There will be some added eventually, at least to test core behaviour.

Deployed to the stage account as `strongmind_dev` 
https://us-west-2.console.aws.amazon.com/vpcconsole/home?region=us-west-2#vpcs:VpcId=vpc-0646a7cf3b9d33d60



[EXCAY2-36]: https://strongmind.atlassian.net/browse/EXCAY2-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ