### PR TITLE
Excay2 34 vpc subnet resolver

### DIFF
--- a/deployment/src/strongmind_deployment/subnet.py
+++ b/deployment/src/strongmind_deployment/subnet.py
@@ -23,6 +23,8 @@ class SubnetType(str, Enum):
     A subnet range which is reserved, but no subnet will be created.
     """
 
+    def __str__(self):
+        return self.value
 
 class SubnetSpec:
     def __init__(self, type: SubnetType,  cidr_blocks: List[str]) -> None:


### PR DESCRIPTION
[EXCAY2-34](https://strongmind.atlassian.net/browse/EXCAY2-34)

## Purpose 
The subnet type tag was placed improperly on the original PR, this fixes that.

It also adds a convenience method to allow other modules (specifially for the ecs module in development) to resolve a VPC's subnets by tags.

This will be used by the alb and ecs components (in development).

Example Usage: 

```python
ecs_args = ecs.EcsComponentArgs(
    vpc_id=vpc_id,
    subnet_placement=vpc.SubnetType.PRIVATE,
```


[EXCAY2-34]: https://strongmind.atlassian.net/browse/EXCAY2-34?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ