### PR TITLE
Add private links for increased security.  Fix NAT Gateway

### DIFF
--- a/deployment/src/strongmind_deployment/vpc.py
+++ b/deployment/src/strongmind_deployment/vpc.py
@@ -273,12 +273,14 @@ class VpcComponent(pulumi.ComponentResource):
         service_name: str,
     ):
         region = aws.get_region().name
+        private_subnet_ids = self.get_subnets(self.vpc.id, SubnetType.PRIVATE)
         aws.ec2.VpcEndpoint(
             f"{service_name}-interface",
             vpc_id=self.vpc.id,
             service_name=f"com.amazonaws.{region}.{service_name}",
             vpc_endpoint_type="Interface",
-            security_group_ids=[self.vpc.default_security_group_id],
+            # security_group_ids=[self.vpc.default_security_group_id],
+            subnet_ids=private_subnet_ids,
             private_dns_enabled=True,
             opts=self.child_opts,
             tags={


### PR DESCRIPTION
[EXCAY2-34](https://strongmind.atlassian.net/browse/EXCAY2-34)

## Purpose 
Private links ensure traffic is travelling within the VPC as opposed to on public networks.  This increases security especially when FERPA is involved.

This also fixes an oversight where the NAT Gateway code was given the private subnet id's, instead of the public ids. :)


## Testing
we don't have test accounts to test this with, so this PR has already been deployed to the stage account.


[EXCAY2-34]: https://strongmind.atlassian.net/browse/EXCAY2-34?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ