### PR TITLE
15.2 to 15.4 for RDS

### DIFF
--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -52,7 +52,7 @@ class RailsComponent(pulumi.ComponentResource):
         :key db_name: The name of the database. Defaults to app.
         :key db_username: The username for connecting to the app database. Defaults to project name and environment.
         :key autoscale: Whether to autoscale the web container. Defaults to True.
-        :key db_engine_version: The version of the database engine. Defaults to 15.2.
+        :key db_engine_version: The version of the database engine. Defaults to 15.4.
         :key desired_web_count: The number of instances of the web container to run. Defaults to 1.
         :key desired_worker_count: The number of instances of the worker container to run. Defaults to 1.
         :key rds_minimum_capacity: The minimum capacity of the RDS cluster. Defaults to 0.5.
@@ -86,7 +86,7 @@ class RailsComponent(pulumi.ComponentResource):
         self.dynamo_tables = self.kwargs.get('dynamo_tables', [])
         self.env_vars = self.kwargs.get('env_vars', {})
         self.autoscale = self.kwargs.get('autoscale', True)
-        self.engine_version = self.kwargs.get('db_engine_version', '15.2')
+        self.engine_version = self.kwargs.get('db_engine_version', '15.4')
         self.desired_web_count = self.kwargs.get('desired_web_count', 1)
         self.desired_worker_count = self.kwargs.get('desired_worker_count', 1)
         self.rds_minimum_capacity = self.kwargs.get('rds_minimum_capacity', 0.5)

--- a/deployment/src/tests/test_rails.py
+++ b/deployment/src/tests/test_rails.py
@@ -334,7 +334,7 @@ def describe_a_pulumi_rails_component():
                 cluster_engine, engine_mode, engine_version = args
                 assert cluster_engine == 'aurora-postgresql'
                 assert engine_mode == 'provisioned'
-                assert engine_version == '15.2'
+                assert engine_version == '15.4'
 
             return pulumi.Output.all(
                 sut.rds_serverless_cluster.engine,


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/DEVOPS-13937)

## Purpose 
Keep our Pulumi deployments up to date with what actually exists in AWS. AWS forcibly upgraded all our RDS instances to 15.4. We need pulumi to be aware.

## Approach 
Change 15.2 to 15.4

## Testing
Deployed repo dashboard and journey tracker.

## Screenshots/Video
<!-- show before/after of the change if possible -->
