### PR TITLE
Excay2 111 update secrets date type

### DIFF
--- a/deployment/src/strongmind_deployment/ecs.py
+++ b/deployment/src/strongmind_deployment/ecs.py
@@ -1,6 +1,6 @@
 from enum import Enum
 import json
-from typing import Mapping, Optional, Dict, Sequence
+from typing import Optional, Dict, Sequence, List
 
 from strongmind_deployment.util import get_project_stack
 import pulumi
@@ -37,7 +37,7 @@ class EcsComponentArgs:
         memory: Optional[int] = None,
         entry_point: Optional[str] = None,
         command: Optional[str] = None,
-        secrets: Optional[Mapping[str, pulumi.Input[str]]] = None,
+        secrets: Optional[List[Dict[str, pulumi.Input[str]]]] = None,
         cpu_architecture: Optional[CpuArchitecture] = CpuArchitecture.X86_64,
     ) -> None:
         self.vpc_id = vpc_id


### PR DESCRIPTION
[[Link to Jira ticket](https://strongmind.atlassian.net/browse/TEAM-NUMBER)](https://strongmind.atlassian.net/browse/EXCAY2-111)

## Purpose 
Do not pass the application the secret arn, but instead pass via ECS Secrets

## Approach 
Instead of using the environment variables for an ECS task, we should use the ECS Secrets.  
This involves setting a secret ARN for each configuration value,  and configuring the key in that secret that is used that should be passed to the container for that secret. ie: the valueFrom field.

## Testing
secrets are in the task definition instead of the env variables 

## Screenshots/Video
<!-- show before/after of the change if possible -->
