### PR TITLE
Add Autoscalling to rails worker

### DIFF
--- a/deployment/src/strongmind_deployment/autoscale.py
+++ b/deployment/src/strongmind_deployment/autoscale.py
@@ -1,0 +1,194 @@
+import pulumi
+import pulumi_aws as aws
+
+class AutoscaleComponent(pulumi.ComponentResource):
+    def __init__(self, name, opts=None, **kwargs):
+        super().__init__('strongmind:global_build:commons:autoscale', name, None, opts)
+        self.project_stack = pulumi.get_project() + "-" + pulumi.get_stack()
+        self.max_capacity = kwargs.get("max_capacity", 10)
+        self.min_capacity = kwargs.get("min_capacity", 1)
+        self.autoscaling()
+    def autoscaling(self):
+
+        self.autoscaling_target = aws.appautoscaling.Target(
+            "autoscaling_target",
+            max_capacity=self.max_capacity,
+            min_capacity=self.min_capacity,
+            resource_id=f"service/{self.project_stack}/{self.project_stack}",
+            scalable_dimension="ecs:service:DesiredCount",
+            service_namespace="ecs",
+        )
+        self.autoscaling_out_policy = aws.appautoscaling.Policy(
+            "autoscaling_out_policy",
+            name=f"{self.project_stack}-autoscaling-out-policy",
+            policy_type="StepScaling",
+            resource_id=self.autoscaling_target.resource_id,
+            scalable_dimension=self.autoscaling_target.scalable_dimension,
+            service_namespace=self.autoscaling_target.service_namespace,
+            step_scaling_policy_configuration=aws.appautoscaling.PolicyStepScalingPolicyConfigurationArgs(
+                adjustment_type="ChangeInCapacity",
+                cooldown=15,
+                metric_aggregation_type="Maximum",
+                step_adjustments=[
+                    aws.appautoscaling.PolicyStepScalingPolicyConfigurationStepAdjustmentArgs(
+                        metric_interval_upper_bound="10",
+                        metric_interval_lower_bound="0",
+                        scaling_adjustment=1,
+                    ),
+                    aws.appautoscaling.PolicyStepScalingPolicyConfigurationStepAdjustmentArgs(
+                        metric_interval_lower_bound="10",
+                        scaling_adjustment=3,
+                    )
+                ],
+            )
+        )
+        self.autoscaling_out_alarm = aws.cloudwatch.MetricAlarm(
+            "autoscaling_alarm",
+            name=f"{self.project_stack}-auto-scaling-out-alarm",
+            comparison_operator="GreaterThanOrEqualToThreshold",
+            evaluation_periods=1,
+            metric_name="CPUUtilization",
+            unit="Percent",
+            dimensions={
+                "ClusterName": self.project_stack,
+                "ServiceName": self.project_stack
+            },
+            namespace="AWS/ECS",
+            period=60,
+            statistic="Average",
+            threshold=65,
+            alarm_actions=[self.autoscaling_out_policy.arn]
+        )
+        self.autoscaling_in_policy = aws.appautoscaling.Policy(
+            "autoscaling_in_policy",
+            name=f"{self.project_stack}-autoscaling-in-policy",
+            policy_type="StepScaling",
+            resource_id=self.autoscaling_target.resource_id,
+            scalable_dimension=self.autoscaling_target.scalable_dimension,
+            service_namespace=self.autoscaling_target.service_namespace,
+            step_scaling_policy_configuration=aws.appautoscaling.PolicyStepScalingPolicyConfigurationArgs(
+                adjustment_type="ChangeInCapacity",
+                cooldown=900,
+                metric_aggregation_type="Maximum",
+                step_adjustments=[
+                    aws.appautoscaling.PolicyStepScalingPolicyConfigurationStepAdjustmentArgs(
+                        metric_interval_upper_bound="0",
+                        scaling_adjustment=-1,
+                    )
+                ],
+            )
+        )
+        self.autoscaling_in_alarm = aws.cloudwatch.MetricAlarm(
+            "autoscaling_in_alarm",
+            name=f"{self.project_stack}-auto-scaling-in-alarm",
+            comparison_operator="LessThanOrEqualToThreshold",
+            evaluation_periods=5,
+            metric_name="CPUUtilization",
+            unit="Percent",
+            dimensions={
+                "ClusterName": self.project_stack,
+                "ServiceName": self.project_stack
+            },
+            namespace="AWS/ECS",
+            period=60,
+            statistic="Average",
+            threshold=50,
+            alarm_actions=[self.autoscaling_in_policy.arn]
+        )
+
+class WorkerAutoscaleComponent(AutoscaleComponent):
+    def __init__(self, name, opts=None, **kwargs):
+        """
+        :worker_max_number_of_instances: The maximum number of instances available in the scaling policy for the worker.
+        :worker_min_number_of_instances: The minimum number of instances available in the scaling policy for the worker.
+        """
+        super().__init__('strongmind:global_build:commons:worker-autoscale', name, None, opts)
+        self.project_stack = pulumi.get_project() + "-" + pulumi.get_stack()
+        self.worker_max_capacity = kwargs.get('worker_max_number_of_instances', 1)
+        self.worker_min_capacity = kwargs.get('worker_min_number_of_instances', 1)
+        self.autoscaling()
+
+# scale out based on EnqueuedJobs metric
+    def autoscaling(self):
+        self.worker_autoscaling_target = aws.appautoscaling.Target(
+            "autoscaling_target",
+            max_capacity=self.worker_max_capacity,
+            min_capacity=self.worker_min_capacity,
+            resource_id=f"service/{self.project_stack}/{self.project_stack}",
+            scalable_dimension="ecs:service:DesiredCount",
+            service_namespace="ecs",
+        )
+        self.worker_autoscaling_out_policy = aws.appautoscaling.Policy(
+            "worker_autoscaling_out_policy",
+            name=f"{self.project_stack}-worker-autoscaling-out-policy",
+            policy_type="StepScaling",
+            resource_id=self.worker_autoscaling_target.resource_id,
+            scalable_dimension=self.worker_autoscaling_target.scalable_dimension,
+            service_namespace=self.worker_autoscaling_target.service_namespace,
+            step_scaling_policy_configuration=aws.appautoscaling.PolicyStepScalingPolicyConfigurationArgs(
+                adjustment_type="ChangeInCapacity",
+                cooldown=60,
+                metric_aggregation_type="Maximum",
+                step_adjustments=[
+                    aws.appautoscaling.PolicyStepScalingPolicyConfigurationStepAdjustmentArgs(
+                        metric_interval_upper_bound=self.worker_max_capacity,
+                        metric_interval_lower_bound="0",
+                        scaling_adjustment=1,
+                    ),
+                ],
+            )
+        )
+        self.worker_autoscaling_out_alarm = aws.cloudwatch.MetricAlarm(
+            "worker_autoscaling_alarm",
+            name=f"{self.project_stack}-worker-auto-scaling-out-alarm",
+            comparison_operator="GreaterThanThreshold",
+            evaluation_periods=1,
+            metric_name="EnqueuedJobs",
+            unit="Count",
+            dimensions={
+                "ClusterName": self.project_stack,
+                "ServiceName": self.project_stack
+            },
+            namespace=self.project_stack,
+            period=60,
+            statistic="Maximum",
+            threshold=1,
+            alarm_actions=[self.worker_autoscaling_out_policy.arn]
+        )
+        self.worker_autoscaling_in_policy = aws.appautoscaling.Policy(
+            "worker_autoscaling_in_policy",
+            name=f"{self.project_stack}-worker-autoscaling-in-policy",
+            policy_type="StepScaling",
+            resource_id=self.worker_autoscaling_target.resource_id,
+            scalable_dimension=self.worker_autoscaling_target.scalable_dimension,
+            service_namespace=self.worker_autoscaling_target.service_namespace,
+            step_scaling_policy_configuration=aws.appautoscaling.PolicyStepScalingPolicyConfigurationArgs(
+                adjustment_type="ChangeInCapacity",
+                cooldown=60,
+                metric_aggregation_type="Maximum",
+                step_adjustments=[
+                    aws.appautoscaling.PolicyStepScalingPolicyConfigurationStepAdjustmentArgs(
+                        metric_interval_upper_bound="0",
+                        scaling_adjustment=-1,
+                    )
+                ],
+            )
+        )
+        self.worker_autoscaling_in_alarm = aws.cloudwatch.MetricAlarm(
+            "worker_autoscaling_in_alarm",
+            name=f"{self.project_stack}-worker-auto-scaling-in-alarm",
+            comparison_operator="LessThanOrEqualToThreshold",
+            evaluation_periods=5,
+            metric_name="EnqueuedJobs",
+            unit="Count",
+            dimensions={
+                "ClusterName": self.project_stack,
+                "ServiceName": self.project_stack
+            },
+            namespace=self.project_stack,
+            period=60,
+            statistic="Maximum",
+            threshold=1,
+            alarm_actions=[self.worker_autoscaling_in_policy.arn]
+        )
+        self.register_outputs({})

--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -177,7 +177,6 @@ class ContainerComponent(pulumi.ComponentResource):
                                 "logs:CreateLogStream",
                                 "logs:PutLogEvents",
                                 "secretsmanager:GetSecretValue",
-                                "cloudwatch:*",
                             ],
                             "Effect": "Allow",
                             "Resource": "*",
@@ -221,7 +220,8 @@ class ContainerComponent(pulumi.ComponentResource):
                                 "ssmmessages:CreateControlChannel",
                                 "ssmmessages:CreateDataChannel",
                                 "ssmmessages:OpenControlChannel",
-                                "ssmmessages:OpenDataChannel"
+                                "ssmmessages:OpenDataChannel",
+                                "clouswatch:*",
                             ],
                             "Effect": "Allow",
                             "Resource": "*",

--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -221,7 +221,7 @@ class ContainerComponent(pulumi.ComponentResource):
                                 "ssmmessages:CreateDataChannel",
                                 "ssmmessages:OpenControlChannel",
                                 "ssmmessages:OpenDataChannel",
-                                "clouswatch:*",
+                                "cloudwatch:*",
                             ],
                             "Effect": "Allow",
                             "Resource": "*",

--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -302,6 +302,12 @@ class ContainerComponent(pulumi.ComponentResource):
 
         if self.kwargs.get('autoscaling'):
             self.autoscaling()
+        if self.kwargs.get('worker_autoscaling'):
+            self.worker_autoscaling = WorkerAutoscaleComponent("worker-autoscale",
+                                                               opts=pulumi.ResourceOptions(parent=self),
+                                                               **self.kwargs)
+
+
 
         self.register_outputs({})
 

--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -9,7 +9,7 @@ import pulumi_awsx as awsx
 from pulumi import Config, export, Output
 from pulumi_awsx.awsx import DefaultRoleWithPolicyArgs
 from pulumi_cloudflare import get_zone, Record
-
+from strongmind_deployment.autoscale import WorkerAutoscaleComponent
 
 class ContainerComponent(pulumi.ComponentResource):
     def __init__(self, name, opts=None, **kwargs):
@@ -177,6 +177,7 @@ class ContainerComponent(pulumi.ComponentResource):
                                 "logs:CreateLogStream",
                                 "logs:PutLogEvents",
                                 "secretsmanager:GetSecretValue",
+                                "cloudwatch:*",
                             ],
                             "Effect": "Allow",
                             "Resource": "*",

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -53,6 +53,7 @@ class RailsComponent(pulumi.ComponentResource):
         :key db_name: The name of the database. Defaults to app.
         :key db_username: The username for connecting to the app database. Defaults to project name and environment.
         :key autoscale: Whether to autoscale the web container. Defaults to True.
+        :key worker_autoscale: Whether to autoscale the worker container. Defaults to False.
         :key db_engine_version: The version of the database engine. Defaults to 15.4.
         :key desired_web_count: The number of instances of the web container to run. Defaults to 1.
         :key desired_worker_count: The number of instances of the worker container to run. Defaults to 1.
@@ -87,6 +88,7 @@ class RailsComponent(pulumi.ComponentResource):
         self.dynamo_tables = self.kwargs.get('dynamo_tables', [])
         self.env_vars = self.kwargs.get('env_vars', {})
         self.autoscale = self.kwargs.get('autoscale', True)
+        self.worker_autoscale = self.kwargs.get('worker_autoscale', False)
         self.engine_version = self.kwargs.get('db_engine_version', '15.4')
         self.desired_web_count = self.kwargs.get('desired_web_count', 1)
         self.desired_worker_count = self.kwargs.get('desired_worker_count', 1)
@@ -279,6 +281,7 @@ class RailsComponent(pulumi.ComponentResource):
                                                    pulumi.ResourceOptions(parent=self,
                                                                           depends_on=[self.execution]
                                                                           ),
+                                                   worker_autoscaling=self.worker_autoscale,
                                                    **self.kwargs
                                                    )
         self.kwargs['log_metric_filters'] = []

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -54,6 +54,9 @@ class RailsComponent(pulumi.ComponentResource):
         :key db_username: The username for connecting to the app database. Defaults to project name and environment.
         :key autoscale: Whether to autoscale the web container. Defaults to True.
         :key worker_autoscale: Whether to autoscale the worker container. Defaults to False.
+        :key worker_max_number_of_instances: The maximum number of instances available in the scaling policy for the worker.
+        :key worker_min_number_of_instances: The minimum number of instances available in the scaling policy for the worker.
+        :key worker_autoscale_threshold: The threshold for the worker autoscaling policy. Default is 3.
         :key db_engine_version: The version of the database engine. Defaults to 15.4.
         :key desired_web_count: The number of instances of the web container to run. Defaults to 1.
         :key desired_worker_count: The number of instances of the worker container to run. Defaults to 1.

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -54,9 +54,6 @@ class RailsComponent(pulumi.ComponentResource):
         :key db_username: The username for connecting to the app database. Defaults to project name and environment.
         :key autoscale: Whether to autoscale the web container. Defaults to True.
         :key worker_autoscale: Whether to autoscale the worker container. Defaults to False.
-        :key worker_max_number_of_instances: The maximum number of instances available in the scaling policy for the worker.
-        :key worker_min_number_of_instances: The minimum number of instances available in the scaling policy for the worker.
-        :key worker_autoscale_threshold: The threshold for the worker autoscaling policy. Default is 3.
         :key db_engine_version: The version of the database engine. Defaults to 15.4.
         :key desired_web_count: The number of instances of the web container to run. Defaults to 1.
         :key desired_worker_count: The number of instances of the worker container to run. Defaults to 1.


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/devops-13589)

## Purpose 
<!-- what/why -->
Add Autoscalling to rails worker
## Approach 
<!-- how -->
Add new autoscale.py with classes for autoscale and worker_autoscale.
Add new kwargs:
  :key worker_autoscale: Whether to autoscale the worker container. Defaults to False.
  :key worker_max_number_of_instances: The maximum number of instances available in the scaling policy for the worker.
  :key worker_min_number_of_instances: The minimum number of instances available in the scaling policy for the worker.
  :key worker_autoscale_threshold: The threshold for the worker autoscaling policy. Default is 3.
Allow threshold input for scale-out alarm. 
Scale workers based on enqueuedjobs metric. 
Scale-in policy will need future adjustments, based on data retrieved from enqueuedjobs metric once apps start publishing. 
More testing is needed on sidekiq-cloudwatchmetrics gem to make sure we can publish faster than 60s intervals before we can adjust scale-out policy cool down period.

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Ran locally on repo-dashboard.
Set production concurrency to 1 to trigger enqueued jobs. 
Verified scaling policies based on published enqueued jobs metric worked.
## Screenshots/Video
<!-- show before/after of the change if possible -->
![image](https://github.com/StrongMind/public-reusable-workflows/assets/101292749/860039c1-0094-49bf-8b74-3b177e640af6)

![image](https://github.com/StrongMind/public-reusable-workflows/assets/101292749/c641ffb2-800a-4962-8b20-4cb50fec4570)

![image](https://github.com/StrongMind/public-reusable-workflows/assets/101292749/fc653d90-912d-4bd1-bb8a-a1089f4a1a22)

![image](https://github.com/StrongMind/public-reusable-workflows/assets/101292749/4c180f10-be4c-4501-b8a4-712b9c36aaac)

![image](https://github.com/StrongMind/public-reusable-workflows/assets/101292749/7e2d0695-b991-4fe9-8b0d-1b1b9a3c79fa)
