### PR TITLE
Devops 13565 - Docker Cache in ECR

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -103,6 +103,7 @@ jobs:
             -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
             --cache-from=type=gha,src=/tmp/.buildx-cache \
             .
+            docker run -d -p 3000:3000 $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
             OUTPUT=$(docker logs $CONTAINER_ID --tail 120)
 
           if [[ $OUTPUT != *"Listening on http://0.0.0.0:3000"* ]]; then

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -106,9 +106,9 @@ jobs:
             .
           echo -e "docker images are \n$(docker images)"
           echo "Running docker tag of $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-          CONTAINER_ID=$(docker run ${{ inputs.test_docker_run_extra_params }} "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG")
+          CONTAINER_ID=$(docker run ${{ inputs.test_docker_run_extra_params }} -d "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG")
           echo -e "Container ID is $CONTAINER_ID and ps:\n $(docker ps -a)"
-          sleep 5
+          sleep 30
           OUTPUT=$(docker logs $CONTAINER_ID)
           echo "docker logs are $OUTPUT"
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -103,6 +103,8 @@ jobs:
             -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
             --cache-from=type=gha,src=/tmp/.buildx-cache \
             .
+
+          echo "Running docker tag of $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
           CONTAINER_ID=$(docker run ${{ inputs.test_docker_run_extra_params }} -d "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG")
           OUTPUT=$(docker logs $CONTAINER_ID)
           echo $OUTPUT

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -84,13 +84,14 @@ jobs:
           ECR_REPOSITORY: ${{ github.event.repository.name }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker buildx --build-arg BUNDLE_GEMS__CONTRIBSYS__COM=${{ env.BUNDLE_GEMS__CONTRIBSYS__COM }} -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          CONTAINER_ID=$(docker run ${{ inputs.test_docker_run_extra_params }} -d "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG")
-          --cache-from type=local,src=/tmp/.buildx-cache
-          --cache-to type=local,dest=/tmp/.buildx-cache-new
-          echo "Starting docker container $CONTAINER_ID and waiting for ${{ inputs.test_docker_timeout }} seconds"
-          sleep ${{ inputs.test_docker_timeout }}
-          OUTPUT=$(docker logs $CONTAINER_ID --tail 120)
+          docker buildx create --use
+          docker buildx build \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
+            --build-arg BUNDLE_GEMS__CONTRIBSYS__COM=${{ env.BUNDLE_GEMS__CONTRIBSYS__COM }} \
+            --cache-from=type=local \
+            --cache-to=type=local \
+            --platform linux/amd64 \
+            .
 
           if [[ $OUTPUT != *"Listening on http://0.0.0.0:3000"* ]]; then
             echo "Dockerfile test failed"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -78,10 +78,7 @@ jobs:
           repository: ${{ github.event.repository.name }}
 
       - name: Check for gemfile change
-        on:
-          push:
-            paths:
-              - '**Gemfile.lock'
+        if: steps.checkout.outputs.changed_files == '**Gemfile.lock'
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ github.event.repository.name }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -104,7 +104,7 @@ jobs:
             --cache-from=type=gha,src=/tmp/.buildx-cache \
             .
             docker run -d -p 3000:3000 $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-            OUTPUT=$(docker logs $CONTAINER_ID --tail 120)
+            OUTPUT=$(docker logs $CONTAINER_ID)
 
           if [[ $OUTPUT != *"Listening on http://0.0.0.0:3000"* ]]; then
             echo "Dockerfile test failed"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -84,7 +84,6 @@ jobs:
           ECR_REPOSITORY: ${{ github.event.repository.name }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker buildx create --use
           docker buildx build \
             -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
             --build-arg BUNDLE_GEMS__CONTRIBSYS__COM=${{ env.BUNDLE_GEMS__CONTRIBSYS__COM }} \

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -88,7 +88,6 @@ jobs:
           docker buildx build --push \
             --cache-from=type=registry,ref=$ECR_REGISTRY/$ECR_REPOSITORY:CACHE \
             --cache-to mode=max,image-manifest=true,oci-mediatypes=true,type=registry,ref=$ECR_REGISTRY/$ECR_REPOSITORY:cache \
-
             -t $ECR_REGISTRY/$ECR_REPOSITORY:CACHE \
             --provenance=false \
             .

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -91,7 +91,6 @@ jobs:
             -t $ECR_REGISTRY/$ECR_REPOSITORY:CACHE \
             --provenance=false \
             .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:CACHE
           
       - name: Test docker and upload to ECR
         env:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -86,9 +86,10 @@ jobs:
         run: |
           echo "Gemfile.lock changed"
           docker buildx build --push \
-            -t $ECR_REGISTRY/$ECR_REPOSITORY:CACHE \
             --cache-from=type=registry,ref=$ECR_REGISTRY/$ECR_REPOSITORY:CACHE \
             --cache-to=$ECR_REGISTRY/$ECR_REPOSITORY:CACHE \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:CACHE \
+            --provenance=false \
             .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:CACHE
           

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -108,6 +108,7 @@ jobs:
           echo "Running docker tag of $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
           CONTAINER_ID=$(docker run ${{ inputs.test_docker_run_extra_params }} -d "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG")
           echo -e "Container ID is $CONTAINER_ID and ps:\n $(docker ps -a)"
+          sleep 5
           OUTPUT=$(docker logs $CONTAINER_ID)
           echo "docker logs are $OUTPUT"
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -89,6 +89,7 @@ jobs:
             --cache-from=type=gha,src=/tmp/.buildx-cache \
             --cache-to=type=gha,dest=/tmp/.buildx-cache-new \
             .
+            OUTPUT=$(docker logs $CONTAINER_ID --tail 120)
 
           if [[ $OUTPUT != *"Listening on http://0.0.0.0:3000"* ]]; then
             echo "Dockerfile test failed"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -103,9 +103,9 @@ jobs:
             -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
             --cache-from=type=gha,src=/tmp/.buildx-cache \
             .
-            CONTAINER_ID=$(docker run ${{ inputs.test_docker_run_extra_params }} -d "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG")
-            OUTPUT=$(docker logs $CONTAINER_ID)
-            echo $OUTPUT
+          CONTAINER_ID=$(docker run ${{ inputs.test_docker_run_extra_params }} -d "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG")
+          OUTPUT=$(docker logs $CONTAINER_ID)
+          echo $OUTPUT
 
           if [[ $OUTPUT != *"Listening on http://0.0.0.0:3000"* ]]; then
             echo "Dockerfile test failed"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -78,14 +78,14 @@ jobs:
           repository: ${{ github.event.repository.name }}
 
       - name: Check for gemfile change
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ github.event.repository.name }}
-          IMAGE_TAG: ${{ github.sha }}
         on:
           push:
             paths:
               - '**Gemfile.lock'
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ github.event.repository.name }}
+          IMAGE_TAG: ${{ github.sha }}
         run: |
           echo "Gemfile.lock changed"
           docker buildx build -- push \

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -87,7 +87,7 @@ jobs:
           echo "Gemfile.lock changed"
           docker buildx build --push \
             --cache-from=type=registry,ref=$ECR_REGISTRY/$ECR_REPOSITORY:CACHE \
-            --cache-to mode=max,image-manifest=true,oci-mediatypes=true,type=registry,ref=$ECR_REGISTRY/$ECR_REPOSITORY:cache \
+            --cache-to mode=max,image-manifest=true,oci-mediatypes=true,type=registry,ref=$ECR_REGISTRY/$ECR_REPOSITORY:CACHE \
             -t $ECR_REGISTRY/$ECR_REPOSITORY:CACHE \
             --provenance=false \
             .
@@ -103,9 +103,9 @@ jobs:
             -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
             --cache-from=type=registry,ref=$ECR_REGISTRY/$ECR_REPOSITORY:CACHE \
             .
-
-          echo "Running docker tag of $ECR_REGISTRY/$ECR_REPOSITORY:CACHE"
-          CONTAINER_ID=$(docker run ${{ inputs.test_docker_run_extra_params }} -d "$ECR_REGISTRY/$ECR_REPOSITORY:CACHE")
+          echo "docker images are $(docker images)"
+          echo "Running docker tag of $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+          CONTAINER_ID=$(docker run ${{ inputs.test_docker_run_extra_params }} -d "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG")
           OUTPUT=$(docker logs $CONTAINER_ID)
           echo $OUTPUT
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -88,8 +88,9 @@ jobs:
           docker buildx build \
             -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
             --build-arg BUNDLE_GEMS__CONTRIBSYS__COM=${{ env.BUNDLE_GEMS__CONTRIBSYS__COM }} \
-            --cache-from=type=local,src=/tmp/.buildx-cache \
-            --cache-to=type=local,dest=/tmp/.buildx-cache-new \
+            --cache-from=type=gha,src=/tmp/.buildx-cache \
+            --cache-to=type=gha,dest=/tmp/.buildx-cache-new \
+            push \
             .
 
           if [[ $OUTPUT != *"Listening on http://0.0.0.0:3000"* ]]; then

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -77,6 +77,24 @@ jobs:
         with:
           repository: ${{ github.event.repository.name }}
 
+      - name: Check for gemfile change
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ github.event.repository.name }}
+          IMAGE_TAG: ${{ github.sha }}
+        on:
+          push:
+            paths:
+              - '**Gemfile.lock'
+        run: |
+          echo "Gemfile.lock changed"
+          docker buildx build -- push \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
+            --cache-from=type=gha,src=/tmp/.buildx-cache \
+            --cache-to=type=gha,dest=/tmp/.buildx-cache-new \
+            .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          
       - name: Test docker and upload to ECR
         env:
           BUNDLE_GEMS__CONTRIBSYS__COM: ${{ secrets.BUNDLE_GEMS__CONTRIBSYS__COM }}
@@ -87,7 +105,6 @@ jobs:
           docker buildx build --push \
             -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
             --cache-from=type=gha,src=/tmp/.buildx-cache \
-            --cache-to=type=gha,dest=/tmp/.buildx-cache-new \
             .
             OUTPUT=$(docker logs $CONTAINER_ID --tail 120)
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -105,6 +105,7 @@ jobs:
             .
             CONTAINER_ID=$(docker run ${{ inputs.test_docker_run_extra_params }} -d "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG")
             OUTPUT=$(docker logs $CONTAINER_ID)
+            echo $OUTPUT
 
           if [[ $OUTPUT != *"Listening on http://0.0.0.0:3000"* ]]; then
             echo "Dockerfile test failed"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -103,7 +103,7 @@ jobs:
             -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
             --cache-from=type=gha,src=/tmp/.buildx-cache \
             .
-            docker run -d -p 3000:3000 $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+            CONTAINER_ID=$(docker run ${{ inputs.test_docker_run_extra_params }} -d "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG")
             OUTPUT=$(docker logs $CONTAINER_ID)
 
           if [[ $OUTPUT != *"Listening on http://0.0.0.0:3000"* ]]; then

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -107,7 +107,7 @@ jobs:
           echo -e "docker images are \n$(docker images)"
           echo "Running docker tag of $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
           CONTAINER_ID=$(docker run ${{ inputs.test_docker_run_extra_params }} -d "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG")
-          echo "Container ID is $CONTAINER_ID"
+          echo -e "Container ID is $CONTAINER_ID and ps:\n $(docker ps -a)"
           OUTPUT=$(docker logs $CONTAINER_ID)
           echo "docker logs are $OUTPUT"
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -106,9 +106,10 @@ jobs:
             .
           echo "docker images are $(docker images)"
           echo "Running docker tag of $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-          CONTAINER_ID=$(docker run ${{ inputs.test_docker_run_extra_params }} -d -it "$IMAGE_TAG")
+          CONTAINER_ID=$(docker run ${{ inputs.test_docker_run_extra_params }} -d "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG")
+          echo "Container ID is $CONTAINER_ID"
           OUTPUT=$(docker logs $CONTAINER_ID)
-          echo $OUTPUT
+          echo "docker logs are $OUTPUT")
 
           if [[ $OUTPUT != *"Listening on http://0.0.0.0:3000"* ]]; then
             echo "Dockerfile test failed"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -86,11 +86,11 @@ jobs:
         run: |
           echo "Gemfile.lock changed"
           docker buildx build -- push \
-            -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
-            --cache-from=type=gha,src=/tmp/.buildx-cache \
-            --cache-to=type=gha,dest=/tmp/.buildx-cache-new \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:CACHE \
+            --cache-from=type=registry,ref=$ECR_REGISTRY/$ECR_REPOSITORY:CACHE \
+            --cache-to=type=registry,ref=$ECR_REGISTRY/$ECR_REPOSITORY:CACHE \
             .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:CACHE
           
       - name: Test docker and upload to ECR
         env:
@@ -99,9 +99,9 @@ jobs:
           ECR_REPOSITORY: ${{ github.event.repository.name }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker buildx build --push \
+          docker buildx build \
             -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
-            --cache-from=type=gha,src=/tmp/.buildx-cache \
+            --cache-from=type=registry,ref=$ECR_REGISTRY/$ECR_REPOSITORY:CACHE \
             .
 
           echo "Running docker tag of $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -102,6 +102,7 @@ jobs:
           docker buildx build \
             -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
             --cache-from=type=registry,ref=$ECR_REGISTRY/$ECR_REPOSITORY:CACHE \
+            --load \
             .
           echo "docker images are $(docker images)"
           echo "Running docker tag of $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -88,7 +88,7 @@ jobs:
           docker buildx build --push \
             -t $ECR_REGISTRY/$ECR_REPOSITORY:CACHE \
             --cache-from=type=registry,ref=$ECR_REGISTRY/$ECR_REPOSITORY:CACHE \
-            --cache-to=type=registry,ref=$ECR_REGISTRY/$ECR_REPOSITORY:CACHE \
+            --cache-to=$ECR_REGISTRY/$ECR_REPOSITORY:CACHE \
             .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:CACHE
           

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -87,7 +87,8 @@ jobs:
           echo "Gemfile.lock changed"
           docker buildx build --push \
             --cache-from=type=registry,ref=$ECR_REGISTRY/$ECR_REPOSITORY:CACHE \
-            --cache-to=$ECR_REGISTRY/$ECR_REPOSITORY:CACHE \
+            --cache-to mode=max,image-manifest=true,oci-mediatypes=true,type=registry,ref=$ECR_REGISTRY/$ECR_REPOSITORY:cache \
+
             -t $ECR_REGISTRY/$ECR_REPOSITORY:CACHE \
             --provenance=false \
             .

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -104,8 +104,8 @@ jobs:
             --cache-from=type=registry,ref=$ECR_REGISTRY/$ECR_REPOSITORY:CACHE \
             .
 
-          echo "Running docker tag of $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-          CONTAINER_ID=$(docker run ${{ inputs.test_docker_run_extra_params }} -d "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG")
+          echo "Running docker tag of $ECR_REGISTRY/$ECR_REPOSITORY:CACHE"
+          CONTAINER_ID=$(docker run ${{ inputs.test_docker_run_extra_params }} -d "$ECR_REGISTRY/$ECR_REPOSITORY:CACHE")
           OUTPUT=$(docker logs $CONTAINER_ID)
           echo $OUTPUT
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -84,12 +84,10 @@ jobs:
           ECR_REPOSITORY: ${{ github.event.repository.name }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker buildx build \
+          docker buildx build --push \
             -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
-            --build-arg BUNDLE_GEMS__CONTRIBSYS__COM=${{ env.BUNDLE_GEMS__CONTRIBSYS__COM }} \
             --cache-from=type=gha,src=/tmp/.buildx-cache \
             --cache-to=type=gha,dest=/tmp/.buildx-cache-new \
-            push \
             .
 
           if [[ $OUTPUT != *"Listening on http://0.0.0.0:3000"* ]]; then

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -78,7 +78,7 @@ jobs:
           repository: ${{ github.event.repository.name }}
 
       - name: Check for gemfile change
-        #if: steps.checkout.outputs.changed_files == '**Gemfile.lock'
+        if: steps.checkout.outputs.changed_files == '**Gemfile.lock'
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ github.event.repository.name }}
@@ -104,13 +104,9 @@ jobs:
             --cache-from=type=registry,ref=$ECR_REGISTRY/$ECR_REPOSITORY:CACHE \
             --load \
             .
-          echo -e "docker images are \n$(docker images)"
-          echo "Running docker tag of $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
           CONTAINER_ID=$(docker run ${{ inputs.test_docker_run_extra_params }} -d "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG")
-          echo -e "Container ID is $CONTAINER_ID and ps:\n $(docker ps -a)"
-          sleep 30
+          sleep ${{ inputs.test_docker_timeout }}
           OUTPUT=$(docker logs $CONTAINER_ID)
-          echo "docker logs are $OUTPUT"
 
           if [[ $OUTPUT != *"Listening on http://0.0.0.0:3000"* ]]; then
             echo "Dockerfile test failed"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -85,7 +85,7 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
         run: |
           echo "Gemfile.lock changed"
-          docker buildx build -- push \
+          docker buildx build --push \
             -t $ECR_REGISTRY/$ECR_REPOSITORY:CACHE \
             --cache-from=type=registry,ref=$ECR_REGISTRY/$ECR_REPOSITORY:CACHE \
             --cache-to=type=registry,ref=$ECR_REGISTRY/$ECR_REPOSITORY:CACHE \

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -106,7 +106,7 @@ jobs:
             .
           echo -e "docker images are \n$(docker images)"
           echo "Running docker tag of $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-          CONTAINER_ID=$(docker run ${{ inputs.test_docker_run_extra_params }} -d "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG")
+          CONTAINER_ID=$(docker run ${{ inputs.test_docker_run_extra_params }} "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG")
           echo -e "Container ID is $CONTAINER_ID and ps:\n $(docker ps -a)"
           sleep 5
           OUTPUT=$(docker logs $CONTAINER_ID)

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -78,7 +78,7 @@ jobs:
           repository: ${{ github.event.repository.name }}
 
       - name: Check for gemfile change
-        if: steps.checkout.outputs.changed_files == '**Gemfile.lock'
+        #if: steps.checkout.outputs.changed_files == '**Gemfile.lock'
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ github.event.repository.name }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -58,7 +58,16 @@ jobs:
           aws-secret-access-key: ${{ secrets.STRONGMIND_AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
           mask-aws-account-id: no
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
 
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
@@ -75,8 +84,10 @@ jobs:
           ECR_REPOSITORY: ${{ github.event.repository.name }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build --build-arg BUNDLE_GEMS__CONTRIBSYS__COM=${{ env.BUNDLE_GEMS__CONTRIBSYS__COM }} -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker buildx --build-arg BUNDLE_GEMS__CONTRIBSYS__COM=${{ env.BUNDLE_GEMS__CONTRIBSYS__COM }} -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           CONTAINER_ID=$(docker run ${{ inputs.test_docker_run_extra_params }} -d "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG")
+          --cache-from type=local,src=/tmp/.buildx-cache
+          --cache-to type=local,dest=/tmp/.buildx-cache-new
           echo "Starting docker container $CONTAINER_ID and waiting for ${{ inputs.test_docker_timeout }} seconds"
           sleep ${{ inputs.test_docker_timeout }}
           OUTPUT=$(docker logs $CONTAINER_ID --tail 120)

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -104,12 +104,12 @@ jobs:
             --cache-from=type=registry,ref=$ECR_REGISTRY/$ECR_REPOSITORY:CACHE \
             --load \
             .
-          echo "docker images are $(docker images)"
+          echo -e "docker images are \n$(docker images)"
           echo "Running docker tag of $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
           CONTAINER_ID=$(docker run ${{ inputs.test_docker_run_extra_params }} -d "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG")
           echo "Container ID is $CONTAINER_ID"
           OUTPUT=$(docker logs $CONTAINER_ID)
-          echo "docker logs are $OUTPUT")
+          echo "docker logs are $OUTPUT"
 
           if [[ $OUTPUT != *"Listening on http://0.0.0.0:3000"* ]]; then
             echo "Dockerfile test failed"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -88,9 +88,8 @@ jobs:
           docker buildx build \
             -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
             --build-arg BUNDLE_GEMS__CONTRIBSYS__COM=${{ env.BUNDLE_GEMS__CONTRIBSYS__COM }} \
-            --cache-from=type=local \
-            --cache-to=type=local \
-            --platform linux/amd64 \
+            --cache-from=type=local,src=/tmp/.buildx-cache \
+            --cache-to=type=local,dest=/tmp/.buildx-cache-new \
             .
 
           if [[ $OUTPUT != *"Listening on http://0.0.0.0:3000"* ]]; then

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -106,7 +106,7 @@ jobs:
             .
           echo "docker images are $(docker images)"
           echo "Running docker tag of $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-          CONTAINER_ID=$(docker run ${{ inputs.test_docker_run_extra_params }} "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG")
+          CONTAINER_ID=$(docker run ${{ inputs.test_docker_run_extra_params }} -d -it "$IMAGE_TAG")
           OUTPUT=$(docker logs $CONTAINER_ID)
           echo $OUTPUT
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -106,7 +106,7 @@ jobs:
             .
           echo "docker images are $(docker images)"
           echo "Running docker tag of $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-          CONTAINER_ID=$(docker run ${{ inputs.test_docker_run_extra_params }} -d "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG")
+          CONTAINER_ID=$(docker run ${{ inputs.test_docker_run_extra_params }} "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG")
           OUTPUT=$(docker logs $CONTAINER_ID)
           echo $OUTPUT
 


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/DEVOPS-13565)

## Purpose 
Allow docker to push max cached layers to ECR.
## Approach 
If a step in docker matches the SHA stored in ECR, that step will skipped during docker run in our CI. This should shorten our ECS deployments by a minute or so. 
## Testing
Tested with repo dashboard https://github.com/StrongMind/repository-dashboard/tree/DEVOPS-13565

## Screenshots/Video
<!-- show before/after of the change if possible -->
