### PR TITLE
Throw exception when mock type not found

### DIFF
--- a/deployment/src/tests/mocks.py
+++ b/deployment/src/tests/mocks.py
@@ -116,7 +116,7 @@ def get_pulumi_mocks(faker, fake_password=None, secret_string="{}"):
                     **args.inputs,
                     "nat_gateways": { "asdf": "asdf"}
                 }
-            
+
             print(args.typ)
 
             return [args.name + '_id', outputs]
@@ -127,6 +127,13 @@ def get_pulumi_mocks(faker, fake_password=None, secret_string="{}"):
                     "arn": f"arn:aws:secretsmanager:us-west-2:123456789013:secret/my-secrets",
                     "secretString": secret_string
                 }
+
+            if args.token == "aws:ec2/getSubnets:getSubnets":
+                return {"ids": ["subnet-12345", "subnet-67890"]}
+
+            raise NotImplementedError(
+                "No mock for: " + args.token + " - change PulimiMocks.call"
+            )
 
     return PulumiMocks()
 


### PR DESCRIPTION
This is done for usability when we need a mock that isn't supported, and speeds up finding out where you need to fix the problem.

[Link to Jira ticket](https://strongmind.atlassian.net/browse/EXCAY2-146)

## Purpose 
When we need a mock for a pulumi call, we were getting confusing errors. We'd like to make the testing experience less confusing.

## Approach 
Add an exception that is thrown with descriptive text when we are calling an AWS pulumi method.

## Testing
Tested in identity project
