### PR TITLE
Add OpsGenie convenience functions

### DIFF
--- a/deployment/src/strongmind_deployment/autotag.py
+++ b/deployment/src/strongmind_deployment/autotag.py
@@ -1,15 +1,25 @@
 # thanks to joeduffy: https://github.com/joeduffy/aws-tags-example/tree/master/autotag-py
 
 import os
-from typing import Dict
 from strongmind_deployment.taggable import is_taggable
 import pulumi
 import subprocess
+
+from strongmind_deployment.operations import get_code_owner_team_name
+
 
 ########################
 ###### Entrypoint ######
 
 class StandardTags:
+    """
+    Represents the default tags that will be assigned to all projects.
+    Dependencies are: 
+     * Pulumi Config files for service and product.
+     * Pulumi Project / Stack for project and environment.
+     * Git for the repository name.
+     * CODEOWNERS file for owner.
+    """
     def __init__(
         self,
         extra_tags: dict,
@@ -27,6 +37,7 @@ class StandardTags:
         self.product = product or config.require("product")
         # get the git repository from the current git repo if not provided
         self.repository = repository or config.get("repository") or get_repo_name()
+        self.owner = get_code_owner_team_name()
 
 
 def get_standard_tags(extra_tags:dict):
@@ -42,6 +53,7 @@ def get_standard_tags(extra_tags:dict):
         "service": standard_tags.service,
         "product": standard_tags.product,
         "repository": standard_tags.repository,
+        "owner": standard_tags.owner,
         **extra_tags,
     }
 

--- a/deployment/src/strongmind_deployment/operations.py
+++ b/deployment/src/strongmind_deployment/operations.py
@@ -1,0 +1,57 @@
+import subprocess
+import pulumi_aws as aws
+import pulumi
+
+def get_code_owner_team_name()-> str:
+    """
+    Gets the code owner from the repositories CODEOWNERS file
+    """
+    path = subprocess.check_output(['git', 'rev-parse', '--show-toplevel']).decode('utf-8').strip()
+    file_path = f"{path}/CODEOWNERS"
+    with open(file_path, 'r') as file:
+        owning_team = [line.strip().split('@')[-1] for line in file if '@' in line][-1].split('/')[1]
+    return owning_team
+
+def get_opsgenie_sns_topic_arn()-> str:
+    """
+    The SNS topic name is coupled to the name in the CODEOWNERS file.
+    The format is <arn_root>:<owning_team>-opsgenie.
+    ex: arn:aws:sns:us-west-2:123456789012:thebestteam-opsgenie
+    """
+    owning_team = get_code_owner_team_name()
+
+    region = aws.get_region().name
+    account_id = aws.get_caller_identity().account_id
+    return f"arn:aws:sns:{region}:{account_id}:{owning_team}-opsgenie"
+
+def get_opsgenie_metric_alarm_config() -> dict:
+    """
+    Returns a dictionary of configuration valid for a pulumi_aws.cloudwatch.MetricAlarm constructor.
+    Specifically:
+        actions_enabled: boolean
+        alarm_actions: [str] # SNS Topic ARN for the specific team
+        ok_actions: [str] # SNS Topic ARN for the specific team
+    
+    Example:
+        from strongmind_deployment import operations 
+        opsgenie_configs = operations.get_opsgenie_metric_alarm_config()
+
+        aws.cloudwatch.MetricAlarm(
+            f"{self.name}-{metric_name}",
+            ...
+            metric_name=metric_name,
+            namespace="AWS/ECS",
+            **opsgenie_configs,
+        )
+
+    """
+    enable_opsgenie = pulumi.Config().get_bool("enable_opsgenie", False)
+    opsgenie_configs = {}
+    if enable_opsgenie:
+        opsgenie_topic = get_opsgenie_sns_topic_arn()
+        opsgenie_configs = {
+            "actions_enabled":True,
+            "alarm_actions":[opsgenie_topic],
+            "ok_actions":[opsgenie_topic],
+        }
+    return opsgenie_configs


### PR DESCRIPTION
[EXCAY2-148](https://strongmind.atlassian.net/browse/EXCAY2-148)

## Purpose 
* Generic code to facilitate configuring alarm actions with their opsgenie SNS Topics.
* Tag all resources with the owner tag

## Approach 
This pulls out some code from rails.py - however does not replace it - related to opsgenie SNS Topic configuration. 

In the same way, we are now parsing the `CODEOWNERS` file to get the team owner, and using that to resolve:

* `owner` tag
* sns topic
* `pulumi_aws.cloudwatch.MetricAlarm` config parameters


## Testing
This was tested with the Identity service. 


[EXCAY2-148]: https://strongmind.atlassian.net/browse/EXCAY2-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ