### PR TITLE
get latest logs via boto3 if ecs task exitCode returns not 0.

### DIFF
--- a/deployment/src/strongmind_deployment/execution.py
+++ b/deployment/src/strongmind_deployment/execution.py
@@ -82,7 +82,21 @@ class ExecutionResourceProvider(pulumi.dynamic.ResourceProvider):
             )
         exit_code = task['tasks'][0]['containers'][0]['exitCode']
         if exit_code:
-            raise Exception(f"Task exited with code {exit_code}")
+            logs = boto3.client('logs')
+            family = str(inputs['family'])
+            log_group_name = f'/aws/ecs/{family}'
+            print(f"Log group name: {log_group_name}")
+            log_stream_name = f'container/{family}/{format(task_id)}'
+            print(f"Log stream name: {log_stream_name}")
+            response = logs.get_log_events(
+                logGroupName=log_group_name,
+                logStreamName=log_stream_name,
+                startFromHead=True
+            )
+            for each in response['events']:
+                print(each['message'])
+
+            raise Execption(f"Task exited with code {exit_code}")
         return True
 
 

--- a/deployment/src/strongmind_deployment/execution.py
+++ b/deployment/src/strongmind_deployment/execution.py
@@ -96,7 +96,7 @@ class ExecutionResourceProvider(pulumi.dynamic.ResourceProvider):
             for each in response['events']:
                 print(each['message'])
 
-            raise Execption(f"Task exited with code {exit_code}")
+            raise Exception(f"Task exited with code {exit_code}")
         return True
 
 


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/DEVOPS-14194)

## Purpose 
If ecs migration fails, we want to retrieve cloudwatch logs.

## Approach 
We already had code that grabs the ecs task status

```
task = self.ecs_client.describe_tasks(
                cluster=inputs['cluster'],
                tasks=[task_id]
            )
```

We just piggy back off of this check. See commit.

## Testing
We forced the migration to 'fail', we received latest cloudwatch logs. 
Caveats:
We only get migration logs. 

## Screenshots/Video
<!-- show before/after of the change if possible -->
