### PR TITLE
Adding bedrock InvokeModel and InvokeModelWithResponseStream to execution policy

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -161,6 +161,8 @@ class ContainerComponent(pulumi.ComponentResource):
                     "Statement": [
                         {
                             "Action": [
+                                "bedrock:InvokeModel",
+                                "bedrock:InvokeModelWithResponseStream",
                                 "ecs:*",
                                 "ecr:GetAuthorizationToken",
                                 "ecr:BatchCheckLayerAvailability",


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/devops-14567)

## Purpose 
<!-- what/why -->
Grant course builder, and in turn all apps using this reusable component, access to Bedrock.
## Approach 
<!-- how -->
Adding minimal permissions needed, as defined by skunks, to the execution policy.
## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Will test and verify in stage course builder after deploy
## Screenshots/Video
<!-- show before/after of the change if possible -->
