### PR TITLE
Update the IAC for cdn.strongmind.com to include the appropriate CORS policy

### DIFF
--- a/deployment/src/strongmind_deployment/cloudfront.py
+++ b/deployment/src/strongmind_deployment/cloudfront.py
@@ -64,6 +64,7 @@ class DistributionComponent(pulumi.ComponentResource):
         stack = kwargs.get('stack')
         origin_domain = bucket.bucket.bucket_regional_domain_name
         origin_id = f"{fqdn_prefix}-origin"
+        cors_with_preflight_policy_id = "5cc3b908-e619-4b99-88e5-2cf7f45965bd"
 
         self.env_name = os.environ.get('ENVIRONMENT_NAME', 'stage')
         project = pulumi.get_project()
@@ -102,11 +103,16 @@ class DistributionComponent(pulumi.ComponentResource):
             allowed_methods=["GET", "HEAD", "OPTIONS", "PUT", "PATCH", "POST", "DELETE"],
             cached_methods=["GET", "HEAD"],
             target_origin_id=origin_id,
+            forwarded_values=aws.cloudfront.DistributionDefaultCacheBehaviorForwardedValuesArgs(
+              query_string=False,
+              headers=["*"],  # Forward all headers for CORS requests
+            ),
             viewer_protocol_policy="redirect-to-https",
             compress=True,
             default_ttl=0,
             max_ttl=0,
             min_ttl=0,
+            response_headers_policy_id=cors_with_preflight_policy_id,
           ),
           restrictions=aws.cloudfront.DistributionRestrictionsArgs(
             geo_restriction=aws.cloudfront.DistributionRestrictionsGeoRestrictionArgs(

--- a/deployment/src/strongmind_deployment/cloudfront.py
+++ b/deployment/src/strongmind_deployment/cloudfront.py
@@ -53,6 +53,7 @@ class DistributionComponent(pulumi.ComponentResource):
             allowed_methods=[
                 "HEAD",
                 "GET",
+                "OPTIONS", # Allow preflight requests
             ],
             allowed_origins=["*"],
             expose_headers=["ETag"],

--- a/deployment/src/strongmind_deployment/cloudfront.py
+++ b/deployment/src/strongmind_deployment/cloudfront.py
@@ -52,8 +52,7 @@ class DistributionComponent(pulumi.ComponentResource):
             allowed_headers=["*"],
             allowed_methods=[
                 "HEAD",
-                "GET",
-                "OPTIONS", # Allow preflight requests
+                "GET"
             ],
             allowed_origins=["*"],
             expose_headers=["ETag"],
@@ -103,10 +102,6 @@ class DistributionComponent(pulumi.ComponentResource):
             allowed_methods=["GET", "HEAD", "OPTIONS", "PUT", "PATCH", "POST", "DELETE"],
             cached_methods=["GET", "HEAD"],
             target_origin_id=origin_id,
-            forwarded_values=aws.cloudfront.DistributionDefaultCacheBehaviorForwardedValuesArgs(
-              query_string=False,
-              headers=["*"],  # Forward all headers for CORS requests
-            ),
             viewer_protocol_policy="redirect-to-https",
             compress=True,
             default_ttl=0,

--- a/deployment/src/strongmind_deployment/cloudfront.py
+++ b/deployment/src/strongmind_deployment/cloudfront.py
@@ -52,7 +52,7 @@ class DistributionComponent(pulumi.ComponentResource):
             allowed_headers=["*"],
             allowed_methods=[
                 "HEAD",
-                "GET"
+                "GET",
             ],
             allowed_origins=["*"],
             expose_headers=["ETag"],


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/devops-14874)

## Purpose 
<!-- what/why -->
Added code to enable CORS with preflight to the IAC code for cloudfront. Deploys with cloudfront will now have CORS policy enabled.

## Approach 
<!-- how -->
Looked at pulumi documentation to find how to add CORS policy to the CloudFront Distribution Behaviour

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Locally Deployed using pulumi to the stage environment. Before and after was tested to confirm if it works.

## Screenshots/Video
<!-- show before/after of the change if possible -->
Before:
![image](https://github.com/StrongMind/public-reusable-workflows/assets/172301408/2262025d-9b5a-4abf-8435-1c91a723d8d3)
After (CORS is enabled):
![image](https://github.com/StrongMind/public-reusable-workflows/assets/172301408/634b08a1-28db-4611-927d-3b06478a5785)
