### PR TITLE
Update PRW loadbalance to write access logs to s3 bucket.

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -435,6 +435,11 @@ class ContainerComponent(pulumi.ComponentResource):
             name=project_stack,
             default_target_group_port=self.container_port,
             tags=self.tags,
+            access_logs=aws.lb.LoadBalancerAccessLogsArgs(
+                bucket = "loadbalancer-logs-221871915463",
+                prefix = self.project_stack,
+                enabled = True,
+            ),
             opts=pulumi.ResourceOptions(parent=self),
         )
         load_balancer_dimension = self.load_balancer.load_balancer.arn.apply(

--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -436,9 +436,9 @@ class ContainerComponent(pulumi.ComponentResource):
             default_target_group_port=self.container_port,
             tags=self.tags,
             access_logs=aws.lb.LoadBalancerAccessLogsArgs(
-                bucket = "loadbalancer-logs-221871915463",
-                prefix = self.project_stack,
-                enabled = True,
+                bucket="loadbalancer-logs-221871915463",
+                prefix=self.project_stack,
+                enabled=True,
             ),
             opts=pulumi.ResourceOptions(parent=self),
         )

--- a/deployment/src/tests/mocks.py
+++ b/deployment/src/tests/mocks.py
@@ -117,6 +117,16 @@ def get_pulumi_mocks(faker, fake_password=None, secret_string="{}"):
                     "nat_gateways": { "asdf": "asdf"}
                 }
 
+            if args.typ == "awsx:lb:ApplicationLoadBalancer":
+                outputs = {
+                    **args.inputs,
+                    "access_logs": {
+                        "bucket": args.inputs["accessLogs"]["bucket"],
+                        "prefix": args.inputs["accessLogs"]["prefix"],
+                        "enabled": args.inputs["accessLogs"]["enabled"],
+                    }
+                }
+
             print(args.typ)
 
             return [args.name + '_id', outputs]

--- a/deployment/src/tests/test_container.py
+++ b/deployment/src/tests/test_container.py
@@ -327,6 +327,15 @@ def describe_container():
             def it_sets_the_load_balancer_name(sut, stack, app_name):
                 return assert_output_equals(sut.load_balancer.name, f"{app_name}-{stack}")
 
+            @pulumi.runtime.test
+            def it_sets_the_access_logs(sut, stack, app_name):
+
+                return assert_output_equals(sut.load_balancer.access_logs, {
+                    "bucket": "loadbalancer-logs-221871915463",
+                    "prefix": f"{app_name}-{stack}",
+                    "enabled": True
+                })
+
             def describe_target_group():
                 @pulumi.runtime.test
                 def it_sets_the_target_group_port(sut, container_port):


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/devops-14859)

## Purpose 
<!-- what/why -->
- Add access logs to awsx load balancer

## Approach 
<!-- how -->
Looked at awsx documentation on how to activate access logs

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Checked if access logs are enabled before and after running pulumi up

## Screenshots/Video
<!-- show before/after of the change if possible -->
