### PR TITLE
BEL-3145: Create a reusable workflow to send the deployment time to repository-dashboard endpoint

### DIFF
--- a/.github/workflows/send-deployment-notification.yml
+++ b/.github/workflows/send-deployment-notification.yml
@@ -16,11 +16,22 @@ jobs:
         id: time
         run: echo "current_time=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_ENV
 
+      - name: Get auth token
+        id: get_token
+        run: |
+          response=$(curl -s -X POST https://login.strongmind.com/connect/token \
+            -d "grant_type=client_credentials" \
+            -d "client_id=${{ secrets.REPOSITORY_DASHBOARD_CLIENT_ID }}" \
+            -d "client_secret=${{ secrets.REPOSITORY_DASHBOARD_CLIENT_SECRET }}")
+          token=$(echo $response | jq -r '.access_token')
+          echo "auth_token=$token" >> $GITHUB_ENV
+
       - name: Send deployment notification
         run: |
           payload=$(jq -n --arg repo "$GITHUB_REPOSITORY" --arg time "$CURRENT_TIME" '{repository_name: $repo, most_recent_period: $time}')
           curl -X POST https://repository-dashboard.strongmind.com/api/deployments \
             -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${{ env.auth_token }}" \
             -d "$payload"
         env:
           GITHUB_REPOSITORY: ${{ inputs.repository_name }}

--- a/.github/workflows/send_deployment_notification.yml
+++ b/.github/workflows/send_deployment_notification.yml
@@ -1,0 +1,27 @@
+name: Send Deployment Notification
+
+on:
+  workflow_call:
+    inputs:
+      repository_name:
+        required: true
+        type: string
+
+jobs:
+  send_notification:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get current time
+        id: time
+        run: echo "current_time=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_ENV
+
+      - name: Send deployment notification
+        run: |
+          payload=$(jq -n --arg repo "$GITHUB_REPOSITORY" --arg time "$CURRENT_TIME" '{repository_name: $repo, most_recent_period: $time}')
+          curl -X POST https://repository-dashboard.strongmind.com/api/deployments \
+            -H "Content-Type: application/json" \
+            -d "$payload"
+        env:
+          GITHUB_REPOSITORY: ${{ inputs.repository_name }}
+          CURRENT_TIME: ${{ env.current_time }}


### PR DESCRIPTION
BEL-3145: Create a reusable workflow to send the deployment time to repository-dashboard endpoint

[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-3145)

## Purpose 
<!-- what/why -->
We need a way to send deployment time to repo dashboard so that it can update the last deployed time. This reusable will send an authenticated request to repo dashboard which will update the time of when the last deploy was successfully ran

## Approach 
<!-- how -->
Get the current time
Get an auth token from identity (Create a new Client and API in login.strongmind.com and devlogin)
Send the payload and auth token to the repo dashboard /api/deployments endpoint