### PR TITLE
Fix Healthy Host Metric Alarm

### DIFF
--- a/deployment/src/strongmind_deployment/autoscale.py
+++ b/deployment/src/strongmind_deployment/autoscale.py
@@ -5,8 +5,8 @@ class AutoscaleComponent(pulumi.ComponentResource):
     def __init__(self, name, opts=None, **kwargs):
         super().__init__('strongmind:global_build:commons:autoscale', name, None, opts)
         self.project_stack = pulumi.get_project() + "-" + pulumi.get_stack()
-        self.max_capacity = kwargs.get("max_capacity", 10)
-        self.min_capacity = kwargs.get("min_capacity", 1)
+        self.max_capacity = kwargs.get("max_capacity")
+        self.min_capacity = kwargs.get("min_capacity")
         self.autoscaling()
     def autoscaling(self):
 

--- a/deployment/src/strongmind_deployment/autoscale.py
+++ b/deployment/src/strongmind_deployment/autoscale.py
@@ -6,14 +6,14 @@ class AutoscaleComponent(pulumi.ComponentResource):
         super().__init__('strongmind:global_build:commons:autoscale', name, None, opts)
         self.project_stack = pulumi.get_project() + "-" + pulumi.get_stack()
         self.max_capacity = kwargs.get("max_capacity")
-        self.min_capacity = kwargs.get("min_capacity")
+        self.desired_count = kwargs.get("desired_count")
         self.autoscaling()
     def autoscaling(self):
 
         self.autoscaling_target = aws.appautoscaling.Target(
             "autoscaling_target",
             max_capacity=self.max_capacity,
-            min_capacity=self.min_capacity,
+            min_capacity=self.desired_count,
             resource_id=f"service/{self.project_stack}/{self.project_stack}",
             scalable_dimension="ecs:service:DesiredCount",
             service_namespace="ecs",

--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -402,6 +402,25 @@ class ContainerComponent(pulumi.ComponentResource):
             threshold=50,
             alarm_actions=[self.autoscaling_in_policy.arn]
         )
+        self.running_tasks_alarm = aws.cloudwatch.MetricAlarm(
+            "running_tasks_alarm",
+            name=f"{self.project_stack}-running-tasks-alarm",
+            comparison_operator="GreaterThanThreshold",
+            evaluation_periods=1,
+            metric_name="RunningTaskCount",
+            namespace="AWS/ECS",
+            dimensions={
+                "ClusterName": self.project_stack,
+                "ServiceName": self.project_stack
+            },
+            period=60,
+            statistic="Maximum",
+            threshold=15,
+            alarm_actions=[self.sns_topic_arn],
+            ok_actions=[self.sns_topic_arn],
+            alarm_description="Alarm when ECS service running tasks exceed 15",
+            tags=self.tags
+        )
 
     def setup_load_balancer(self, kwargs, project, project_stack, stack):
         default_vpc = awsx.ec2.DefaultVpc("default_vpc")

--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -10,6 +10,7 @@ from pulumi import Config, export, Output
 from pulumi_awsx.awsx import DefaultRoleWithPolicyArgs
 from pulumi_cloudflare import get_zone, Record
 from strongmind_deployment.autoscale import WorkerAutoscaleComponent
+from strongmind_deployment.util import create_ecs_cluster
 
 class ContainerComponent(pulumi.ComponentResource):
     def __init__(self, name, opts=None, **kwargs):

--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -58,7 +58,7 @@ class ContainerComponent(pulumi.ComponentResource):
         self.env_name = os.environ.get('ENVIRONMENT_NAME', 'stage')
         self.autoscaling_target = None
         self.autoscaling_out_policy = None
-        self.desired_count = kwargs.get('desired_count')
+        self.desired_count = kwargs.get('desired_count', 2)
         self.max_capacity = 100
         self.min_capacity = self.desired_count
         self.sns_topic_arn = kwargs.get('sns_topic_arn', 'arn:aws:sns:us-west-2:221871915463:DevOps-Opsgenie')

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -14,6 +14,9 @@ from strongmind_deployment.redis import RedisComponent, QueueComponent, CacheCom
 from strongmind_deployment.secrets import SecretsComponent
 from strongmind_deployment.storage import StorageComponent
 from strongmind_deployment.dashboard import DashboardComponent
+from strongmind_deployment.util import create_ecs_cluster
+
+
 
 
 def sidekiq_present():  # pragma: no cover
@@ -169,11 +172,7 @@ class RailsComponent(pulumi.ComponentResource):
         stack = pulumi.get_stack()
         project = pulumi.get_project()
         project_stack = f"{project}-{stack}"
-        self.ecs_cluster = aws.ecs.Cluster("cluster",
-                                           name=project_stack,
-                                           tags=self.tags,
-                                           opts=pulumi.ResourceOptions(parent=self),
-                                           )
+        self.ecs_cluster = create_ecs_cluster(self, project_stack)
         self.kwargs['ecs_cluster_arn'] = self.ecs_cluster.arn
 
         container_image = os.environ['CONTAINER_IMAGE']

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -55,7 +55,6 @@ class RailsComponent(pulumi.ComponentResource):
         :key kms_key_id: The KMS key ID to use for the RDS cluster. Defaults to None.
         :key db_name: The name of the database. Defaults to app.
         :key db_username: The username for connecting to the app database. Defaults to project name and environment.
-        :key autoscale: Whether to autoscale the web container. Defaults to True.
         :key worker_autoscale: Whether to autoscale the worker container. Defaults to False.
         :key db_engine_version: The version of the database engine. Defaults to 15.4.
         :key desired_worker_count: The number of instances of the worker container to run. Defaults to 1.

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -55,7 +55,6 @@ class RailsComponent(pulumi.ComponentResource):
         :key autoscale: Whether to autoscale the web container. Defaults to True.
         :key worker_autoscale: Whether to autoscale the worker container. Defaults to False.
         :key db_engine_version: The version of the database engine. Defaults to 15.4.
-        :key desired_web_count: The number of instances of the web container to run. Defaults to 1.
         :key desired_worker_count: The number of instances of the worker container to run. Defaults to 1.
         :key rds_minimum_capacity: The minimum capacity of the RDS cluster. Defaults to 0.5.
         :key rds_maximum_capacity: The maximum capacity of the RDS cluster. Defaults to 16.
@@ -90,7 +89,7 @@ class RailsComponent(pulumi.ComponentResource):
         self.autoscale = self.kwargs.get('autoscale', True)
         self.worker_autoscale = self.kwargs.get('worker_autoscale', False)
         self.engine_version = self.kwargs.get('db_engine_version', '15.4')
-        self.desired_web_count = self.kwargs.get('desired_web_count', 1)
+        self.desired_web_count = 2
         self.desired_worker_count = self.kwargs.get('desired_worker_count', 1)
         self.rds_minimum_capacity = self.kwargs.get('rds_minimum_capacity', 0.5)
         self.rds_maximum_capacity = self.kwargs.get('rds_maximum_capacity', 16)

--- a/deployment/src/strongmind_deployment/util.py
+++ b/deployment/src/strongmind_deployment/util.py
@@ -2,12 +2,12 @@ import pulumi
 import pulumi_aws as aws
 
 def get_project_stack() -> str:
-  """
-  Typically used in pulumi logical and physical resource naming
-  """
-  stack = pulumi.get_stack()
-  project = pulumi.get_project()
-  return f"{project}-{stack}"
+    """
+    Typically used in pulumi logical and physical resource naming
+    """
+    stack = pulumi.get_stack()
+    project = pulumi.get_project()
+    return f"{project}-{stack}"
 
 def get_stack_project() -> str:
     """
@@ -25,3 +25,15 @@ def get_account_stack_name(force_stack: str = None) -> str:
     account_stack_name = alias.replace("-","_")
     account_stack = force_stack or account_stack_name
     return f"organization/account/{account_stack}"
+
+
+def create_ecs_cluster(parent_component, project_stack):
+    return aws.ecs.Cluster("cluster",
+                           name=project_stack,
+                           tags=parent_component.tags,
+                           settings=[{
+                               "name": "containerInsights",
+                               "value": "enabled",
+                           }],
+                           opts=pulumi.ResourceOptions(parent=parent_component),
+                           )

--- a/deployment/src/tests/test_container_autoscaling.py
+++ b/deployment/src/tests/test_container_autoscaling.py
@@ -19,7 +19,7 @@ def describe_autoscaling():
 
         @pulumi.runtime.test
         def it_has_a_default_max_capacity(sut):
-            return assert_output_equals(sut.autoscaling_target.max_capacity, 1)
+            return assert_output_equals(sut.autoscaling_target.max_capacity, 100)
 
         def describe_autoscaling_overrides():
             @pytest.fixture
@@ -27,13 +27,9 @@ def describe_autoscaling():
                 component_kwargs["max_number_of_instances"] = 10
                 return component_kwargs
 
-            @pulumi.runtime.test
-            def it_has_a_configurable_max_capacity(sut):
-                return assert_output_equals(sut.autoscaling_target.max_capacity, 10)
-
         @pulumi.runtime.test
         def it_has_a_default_min_capacity(sut):
-            return assert_output_equals(sut.autoscaling_target.min_capacity, 1)
+            return assert_output_equals(sut.autoscaling_target.min_capacity, 2)
 
         @pulumi.runtime.test
         def it_has_a_default_scalable_dimension_of_desired_count(sut):

--- a/docs/rails-app-deployment.md
+++ b/docs/rails-app-deployment.md
@@ -83,4 +83,4 @@ component = RailsComponent("rails", autoscale=False)
 
 ## Autoscaling
 
-When necessary, remove `autoscale=false` from the `infrastructure/__main__.py` file and redeploy.
+Remove `autoscale=false` from the `infrastructure/__main__.py` file and redeploy.


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/bel-3356)

## Purpose 
<!-- what/why -->
As a devops engineer, I should not be alerted by a healthy host metric alarm due to conflicts in code configuration.
## Approach 
<!-- how -->
Set a default desired count for number of web containers.
Set the min_capacity for web autoscaling to match desired count.
Turn on container insights for ECS clusters.
Create a new alarm based on RunningTaskCount which is now provided by container insights.
## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
All tests pass.
Tested on tools using pulumi locally. -see screenshot below to verify that desired count is changed and running task alarm is created and container insights is turned on.
## Screenshots/Video
<!-- show before/after of the change if possible -->
![image](https://gi
![image](https://github.com/user-attachments/assets/3bc86cdd-7375-4a33-9010-671f6c2bd5a6)
thub.com/user-attachments/assets/9441035a-ae51-44c0-8d5d-46ce15c0993c)
![image](https://github.com/user-attachments/assets/25b24e6b-1b4e-4506-ad92-cad70278733f)
