### PR TITLE
BEL-3216 Switch to Alb component built by Caylent to remove listener on port 3000

### DIFF
--- a/deployment/src/strongmind_deployment/alb.py
+++ b/deployment/src/strongmind_deployment/alb.py
@@ -29,6 +29,7 @@ class AlbArgs:
     def __init__(
         self,
         vpc_id: str,
+        subnets: Sequence[str],
         certificate_arn: str,
         placement: Optional[AlbPlacement] = AlbPlacement.EXTERNAL,
         internal_ingress_cidrs: list[str] = [],
@@ -36,6 +37,7 @@ class AlbArgs:
         should_protect: bool = False,
     ):
         self.vpc_id = vpc_id
+        self.subnets = subnets
         self.certificate_arn = certificate_arn
         self.placement = placement or AlbPlacement.EXTERNAL
         self.internal_ingress_cidrs = internal_ingress_cidrs
@@ -58,7 +60,10 @@ class Alb(pulumi.ComponentResource):
         self.args = args
         self.is_internal = args.placement == AlbPlacement.INTERNAL
         self.subnet_placement: vpc.SubnetType = vpc.SubnetType.PRIVATE if self.is_internal else vpc.SubnetType.PUBLIC
-        self.subnet_ids: Sequence[str] = vpc.VpcComponent.get_subnets(vpc_id=args.vpc_id, placement=args.placement)
+        if args.subnets:
+            self.subnet_ids = args.subnets
+        else:
+            self.subnet_ids: Sequence[str] = vpc.VpcComponent.get_subnets(vpc_id=args.vpc_id, placement=args.placement)
         stack = pulumi.get_stack()
         project = pulumi.get_project()[:18]
         self.project_stack = f"{project}-{stack}"

--- a/deployment/src/strongmind_deployment/alb.py
+++ b/deployment/src/strongmind_deployment/alb.py
@@ -75,7 +75,7 @@ class Alb(pulumi.ComponentResource):
     def create_resources(self):
         self.alb = self.create_loadbalancer()
         self.https_listener = self.create_https_listener()
-        self.create_port_80_redirect_listener()
+        self.redirect_listener = self.create_port_80_redirect_listener()
 
     def create_loadbalancer(self)-> lb.LoadBalancer:
 
@@ -111,6 +111,11 @@ class Alb(pulumi.ComponentResource):
             security_groups=[alb_security_group.id],
             subnets=self.subnet_ids,
             enable_deletion_protection=self.args.should_protect,
+            access_logs=lb.LoadBalancerAccessLogsArgs(
+                bucket="loadbalancer-logs-221871915463",
+                prefix=self.project_stack,
+                enabled=True,
+            ),
             opts=self.child_opts,
         )
         return alb
@@ -147,6 +152,7 @@ class Alb(pulumi.ComponentResource):
         port_80_redirect_listener = aws.alb.Listener(
             f"{self.project_stack}-80-redirect-443",
             load_balancer_arn=self.alb.arn,
+            protocol="HTTP",
             port=80,
             default_actions=[
                 {

--- a/deployment/src/strongmind_deployment/alb.py
+++ b/deployment/src/strongmind_deployment/alb.py
@@ -106,6 +106,8 @@ class Alb(pulumi.ComponentResource):
 
         self.add_ingress_rules_to_security_group(security_group=alb_security_group)
 
+        current = aws.get_caller_identity()
+
         alb = lb.LoadBalancer(
             self.project_stack,
             internal=self.is_internal,
@@ -114,7 +116,7 @@ class Alb(pulumi.ComponentResource):
             subnets=self.subnet_ids,
             enable_deletion_protection=self.args.should_protect,
             access_logs=lb.LoadBalancerAccessLogsArgs(
-                bucket="loadbalancer-logs-221871915463",
+                bucket=f"loadbalancer-logs-{current.account_id}",
                 prefix=self.project_stack,
                 enabled=True,
             ),

--- a/deployment/src/strongmind_deployment/alb.py
+++ b/deployment/src/strongmind_deployment/alb.py
@@ -57,6 +57,8 @@ class Alb(pulumi.ComponentResource):
     def __init__(self, name: str, args: AlbArgs, opts=None):
         super().__init__("strongmind:global_build:commons:alb", name, {}, opts)
 
+        self.http_ingress = None
+        self.tls_ingress = None
         self.args = args
         self.is_internal = args.placement == AlbPlacement.INTERNAL
         self.subnet_placement: vpc.SubnetType = vpc.SubnetType.PRIVATE if self.is_internal else vpc.SubnetType.PUBLIC
@@ -186,7 +188,7 @@ class Alb(pulumi.ComponentResource):
             )
 
         if not self.is_internal:
-            ec2.SecurityGroupRule(
+            self.tls_ingress = ec2.SecurityGroupRule(
                 "tls_ingress",
                 description="TLS internet",
                 type="ingress",
@@ -198,7 +200,7 @@ class Alb(pulumi.ComponentResource):
                 ],
                 security_group_id=security_group.id,
             )
-            ec2.SecurityGroupRule(
+            self.http_ingress = ec2.SecurityGroupRule(
                 "http_ingress",
                 description="Internet",
                 type="ingress",

--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -9,6 +9,8 @@ import pulumi_awsx as awsx
 from pulumi import Config, export, Output
 from pulumi_awsx.awsx import DefaultRoleWithPolicyArgs
 from pulumi_cloudflare import get_zone, Record
+
+from strongmind_deployment import alb
 from strongmind_deployment.autoscale import WorkerAutoscaleComponent
 
 class ContainerComponent(pulumi.ComponentResource):
@@ -410,6 +412,8 @@ class ContainerComponent(pulumi.ComponentResource):
         )
 
     def setup_load_balancer(self, kwargs, project, project_stack, stack):
+        self.certificate(project, stack)
+
         default_vpc = awsx.ec2.DefaultVpc("default_vpc")
         health_check_path = kwargs.get('custom_health_check_path', '/up')
 
@@ -433,19 +437,35 @@ class ContainerComponent(pulumi.ComponentResource):
             ),
         )
 
-        self.load_balancer = awsx.lb.ApplicationLoadBalancer(
-            "loadbalancer",
-            name=project_stack,
-            default_target_group_port=self.container_port,
-            tags=self.tags,
-            access_logs=aws.lb.LoadBalancerAccessLogsArgs(
-                bucket="loadbalancer-logs-221871915463",
-                prefix=self.project_stack,
-                enabled=True,
-            ),
-            opts=pulumi.ResourceOptions(parent=self),
+        alb_args = alb.AlbArgs(
+            vpc_id=default_vpc.vpc_id,
+            subnets=default_vpc.public_subnet_ids,
+            placement=alb.AlbPlacement.EXTERNAL,
+            certificate_arn=self.cert.arn,
         )
-        load_balancer_dimension = self.load_balancer.load_balancer.arn.apply(
+        self.alb = alb.Alb("loadbalancer", alb_args)
+        self.load_balancer = self.alb.alb
+
+        aws.lb.ListenerRule(
+            "service_listener_rule",
+            listener_arn=self.alb.https_listener.arn,
+            priority=1000,
+            actions=[
+                aws.lb.ListenerRuleActionArgs(
+                    type="forward", target_group_arn=self.target_group.arn
+                )
+            ],
+            conditions=[
+                aws.lb.ListenerRuleConditionArgs(
+                    path_pattern=aws.lb.ListenerRuleConditionPathPatternArgs(
+                        values=["/*"]
+                    )
+                )
+            ],
+        )
+
+
+        load_balancer_dimension = self.load_balancer.arn.apply(
             lambda arn: arn.split("/")[-1]
         )
         target_group_dimension = self.target_group.arn.apply(
@@ -475,40 +495,16 @@ class ContainerComponent(pulumi.ComponentResource):
         )
 
         self.dns(project, stack)
-        load_balancer_arn = kwargs.get('load_balancer_arn', self.load_balancer.load_balancer.arn)
-        target_group_arn = kwargs.get('target_group_arn', self.target_group.arn)
-        self.load_balancer_listener = aws.lb.Listener(
-            "listener443",
-            load_balancer_arn=load_balancer_arn,
-            certificate_arn=self.cert.arn,
-            port=443,
-            protocol="HTTPS",
-            default_actions=[
-                aws.lb.ListenerDefaultActionArgs(
-                    type="forward",
-                    target_group_arn=target_group_arn
-                )],
-            tags=self.tags,
-            opts=pulumi.ResourceOptions(parent=self,
-                                        depends_on=[
-                                            self.cert,
-                                            self.cert_validation_record,
-                                            self.cert_validation_cert,
-                                        ]),
-        )
-        self.load_balancer_listener_redirect_http_to_https = aws.lb.Listener(
-            "listener80",
-            load_balancer_arn=load_balancer_arn,
-            port=80,
-            protocol="HTTP",
-            default_actions=[aws.lb.ListenerDefaultActionArgs(
-                type="redirect",
-                redirect=aws.lb.ListenerDefaultActionRedirectArgs(
-                    port="443",
-                    protocol="HTTPS",
-                    status_code="HTTP_301",
-                ),
-            )],
+
+    def certificate(self, name, stack):
+        if stack != "prod":
+            name = f"{stack}-{name}"
+        domain = 'strongmind.com'
+        full_name = f"{name}.{domain}"
+        self.cert = aws.acm.Certificate(
+            "cert",
+            domain_name=full_name,
+            validation_method="DNS",
             tags=self.tags,
             opts=pulumi.ResourceOptions(parent=self),
         )
@@ -520,7 +516,7 @@ class ContainerComponent(pulumi.ComponentResource):
         full_name = f"{name}.{domain}"
         zone_id = self.kwargs.get('zone_id', 'b4b7fec0d0aacbd55c5a259d1e64fff5')
         lb_dns_name = self.kwargs.get('load_balancer_dns_name',
-                                      self.load_balancer.load_balancer.dns_name)  # pragma: no cover
+                                      self.load_balancer.dns_name)  # pragma: no cover
         if self.kwargs.get('cname', True):
             self.cname_record = Record(
                 'cname_record',
@@ -533,13 +529,6 @@ class ContainerComponent(pulumi.ComponentResource):
             )
         pulumi.export("url", Output.concat("https://", full_name))
 
-        self.cert = aws.acm.Certificate(
-            "cert",
-            domain_name=full_name,
-            validation_method="DNS",
-            tags=self.tags,
-            opts=pulumi.ResourceOptions(parent=self),
-        )
         domain_validation_options = self.kwargs.get('domain_validation_options',
                                                     self.cert.domain_validation_options)  # pragma: no cover
 

--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -419,8 +419,8 @@ class ContainerComponent(pulumi.ComponentResource):
         health_check_path = kwargs.get('custom_health_check_path', '/up')
 
         self.target_group = aws.lb.TargetGroup(
-            "targetgroup",
-            name=project_stack,
+            "target_group",
+            name=f"{project_stack}-tg",
             port=self.container_port,
             protocol="HTTP",
             target_type="ip",

--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -445,8 +445,10 @@ class ContainerComponent(pulumi.ComponentResource):
         )
         self.alb = alb.Alb("loadbalancer", alb_args)
         self.load_balancer = self.alb.alb
+        self.load_balancer_listener = self.alb.https_listener
+        self.load_balancer_listener_redirect_http_to_https = self.alb.redirect_listener
 
-        aws.lb.ListenerRule(
+        self.listener_rule = aws.lb.ListenerRule(
             "service_listener_rule",
             listener_arn=self.alb.https_listener.arn,
             priority=1000,

--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -39,6 +39,7 @@ class ContainerComponent(pulumi.ComponentResource):
         """
         super().__init__('strongmind:global_build:commons:container', name, None, opts)
 
+        self.alb = None
         self.autoscaling_out_alarm = None
         self.log_metric_filters = []
         self.target_group = None

--- a/deployment/src/strongmind_deployment/dashboard.py
+++ b/deployment/src/strongmind_deployment/dashboard.py
@@ -19,7 +19,7 @@ class DashboardComponent(pulumi.ComponentResource):
 
     def setup_dashboard(self, project_stack, **kwargs):
         self.log_metric_filter_definitions = self.kwargs.get('log_metric_filters', [])
-        load_balancer_arn = kwargs.get('load_balancer_arn', self.web_container.load_balancer.load_balancer.arn)
+        load_balancer_arn = kwargs.get('load_balancer_arn', self.web_container.load_balancer.arn)
         self.load_balancer_arn_name = load_balancer_arn.apply(lambda arn: arn.split("loadbalancer/")[1])
         self.target_group_arn = self.web_container.target_group.arn.apply(lambda arn: arn.split(":")[-1])
         widgets = []

--- a/deployment/src/tests/mocks.py
+++ b/deployment/src/tests/mocks.py
@@ -143,6 +143,13 @@ def get_pulumi_mocks(faker, fake_password=None, secret_string="{}"):
             if args.token == "aws:ec2/getSecurityGroup:getSecurityGroup":
                 return {"id": "sg-12345"}
 
+            if args.token == "aws:index/getCallerIdentity:getCallerIdentity":
+                return {
+                    "account_id": "123456789012",
+                    "arn": "arn:aws:sts::123456789012:assumed-role/pulumi/pulumi",
+                    "user_id": "AIDAJDPLRKLG7UEXAMPLE",
+                }
+
             raise NotImplementedError(
                 "No mock for: " + args.token + " - change PulimiMocks.call"
             )

--- a/deployment/src/tests/mocks.py
+++ b/deployment/src/tests/mocks.py
@@ -117,14 +117,10 @@ def get_pulumi_mocks(faker, fake_password=None, secret_string="{}"):
                     "nat_gateways": { "asdf": "asdf"}
                 }
 
-            if args.typ == "awsx:lb:ApplicationLoadBalancer":
+            if args.typ == "aws:lb/loadBalancer:LoadBalancer":
                 outputs = {
                     **args.inputs,
-                    "access_logs": {
-                        "bucket": args.inputs["accessLogs"]["bucket"],
-                        "prefix": args.inputs["accessLogs"]["prefix"],
-                        "enabled": args.inputs["accessLogs"]["enabled"],
-                    }
+                    "arn": f"arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/{faker.word()}",
                 }
 
             print(args.typ)

--- a/deployment/src/tests/test_container.py
+++ b/deployment/src/tests/test_container.py
@@ -72,14 +72,6 @@ def a_pulumi_containerized_app():
         }]
 
     @pytest.fixture
-    def load_balancer_arn(faker):
-        return f"arn:aws:elasticloadbalancing:us-west-2:{faker.random_int()}:loadbalancer/app/{faker.word()}/{faker.random_int()}"
-
-    @pytest.fixture
-    def target_group_arn(faker):
-        return f"arn:aws:elasticloadbalancing:us-west-2:{faker.random_int()}:targetgroup/{faker.word()}/{faker.random_int()}"
-
-    @pytest.fixture
     def zone_id(faker):
         return faker.word()
 
@@ -127,8 +119,6 @@ def a_pulumi_containerized_app():
                          container_image,
                          env_vars,
                          secrets,
-                         load_balancer_arn,
-                         target_group_arn,
                          zone_id,
                          load_balancer_dns_name,
                          domain_validation_options,
@@ -143,8 +133,6 @@ def a_pulumi_containerized_app():
             "container_image": container_image,
             "env_vars": env_vars,
             "secrets": secrets,
-            "load_balancer_arn": load_balancer_arn,
-            "target_group_arn": target_group_arn,
             "zone_id": zone_id,
             "load_balancer_dns_name": load_balancer_dns_name,
             "domain_validation_options": domain_validation_options
@@ -328,16 +316,25 @@ def describe_container():
 
             @pulumi.runtime.test
             def it_sets_the_load_balancer_name(sut, stack, app_name):
-                return assert_output_equals(sut.load_balancer.name, f"{app_name}-{stack}")
+                assert sut.load_balancer._name == f"{app_name}-{stack}"
 
             @pulumi.runtime.test
-            def it_sets_the_access_logs(sut, stack, app_name):
-
-                return assert_output_equals(sut.load_balancer.access_logs, {
+            def it_sets_the_access_log_bucket(sut, stack, app_name):
+                expected = {
                     "bucket": "loadbalancer-logs-221871915463",
+                    "enabled": True,
                     "prefix": f"{app_name}-{stack}",
-                    "enabled": True
-                })
+                }
+
+                def compare(value):
+                    try:
+                        assert str(value) == str(expected)
+                    except AssertionError:
+                        print(f"Expected: {expected}")
+                        print(f"Actual: {value}")
+                        raise
+
+                return sut.load_balancer.access_logs.apply(compare)
 
             def describe_target_group():
                 @pulumi.runtime.test
@@ -385,13 +382,17 @@ def describe_container():
                 def listener(sut):
                     return sut.load_balancer_listener
 
+                @pytest.fixture
+                def listener_rule(sut):
+                    return sut.listener_rule
+
                 @pulumi.runtime.test
                 def it_has_load_balancer_listener_for_https(listener):
                     assert listener
 
                 @pulumi.runtime.test
-                def it_sets_the_load_balancer_arn(listener, load_balancer_arn):
-                    return assert_output_equals(listener.load_balancer_arn, load_balancer_arn)
+                def it_sets_the_load_balancer_arn(listener, sut):
+                    return assert_outputs_equal(listener.load_balancer_arn, sut.load_balancer.arn)
 
                 @pulumi.runtime.test
                 def it_sets_the_certificate_arn(listener, sut):
@@ -406,12 +407,16 @@ def describe_container():
                     return assert_output_equals(listener.protocol, "HTTPS")
 
                 @pulumi.runtime.test
-                def it_forwards_to_the_target_group(listener, target_group_arn):
-                    return assert_output_equals(listener.default_actions[0].target_group_arn, target_group_arn)
+                def it_has_a_listener_rule_connected_to_the_listener(listener_rule, listener):
+                    return assert_outputs_equal(listener_rule.listener_arn, listener.arn)
 
                 @pulumi.runtime.test
-                def it_forwards(listener):
-                    return assert_output_equals(listener.default_actions[0].type, "forward")
+                def it_forwards_to_the_target_group_with_a_rule(listener_rule, sut):
+                    return assert_outputs_equal(listener_rule.actions[0].target_group_arn, sut.target_group.arn)
+
+                @pulumi.runtime.test
+                def it_forwards(listener_rule):
+                    return assert_output_equals(listener_rule.actions[0].type, "forward")
 
             def describe_the_load_balancer_listener_for_http():
                 @pytest.fixture
@@ -423,8 +428,8 @@ def describe_container():
                     assert listener
 
                 @pulumi.runtime.test
-                def it_sets_the_load_balancer_arn(listener, load_balancer_arn):
-                    return assert_output_equals(listener.load_balancer_arn, load_balancer_arn)
+                def it_sets_the_load_balancer_arn(listener, sut):
+                    return assert_outputs_equal(listener.load_balancer_arn, sut.load_balancer.arn)
 
                 @pulumi.runtime.test
                 def it_sets_the_port(listener):

--- a/deployment/src/tests/test_container.py
+++ b/deployment/src/tests/test_container.py
@@ -418,6 +418,22 @@ def describe_container():
                 def it_forwards(listener_rule):
                     return assert_output_equals(listener_rule.actions[0].type, "forward")
 
+                @pulumi.runtime.test
+                def it_defaults_to_fixed_response(listener):
+                    return assert_output_equals(listener.default_actions[0].type, "fixed-response")
+
+                @pulumi.runtime.test
+                def it_defaults_to_404(listener):
+                    return assert_output_equals(listener.default_actions[0].fixed_response.status_code, "404")
+
+                @pulumi.runtime.test
+                def it_defaults_to_text_plain(listener):
+                    return assert_output_equals(listener.default_actions[0].fixed_response.content_type, "text/plain")
+
+                @pulumi.runtime.test
+                def it_defaults_to_path_not_found(listener):
+                    return assert_output_equals(listener.default_actions[0].fixed_response.message_body, "Path Not Found")
+
             def describe_the_load_balancer_listener_for_http():
                 @pytest.fixture
                 def listener(sut):

--- a/deployment/src/tests/test_container.py
+++ b/deployment/src/tests/test_container.py
@@ -459,6 +459,56 @@ def describe_container():
                 def it_redirects(redirect_action):
                     return assert_output_equals(redirect_action.type, "redirect")
 
+            def describe_security_group_rules():
+                @pytest.fixture
+                def tls_ingress(sut):
+                    return sut.alb.tls_ingress
+
+                @pytest.fixture
+                def http_ingress(sut):
+                    return sut.alb.http_ingress
+
+                @pulumi.runtime.test
+                def it_allows_tls_ingress_from_anywhere(tls_ingress):
+                    return assert_output_equals(tls_ingress.cidr_blocks, ["0.0.0.0/0"])
+
+                @pulumi.runtime.test
+                def it_allows_tls_ingress_on_port_443(tls_ingress):
+                    return assert_output_equals(tls_ingress.from_port, 443)
+
+                @pulumi.runtime.test
+                def it_allows_http_ingress_from_anywhere(http_ingress):
+                    return assert_output_equals(http_ingress.cidr_blocks, ["0.0.0.0/0"])
+
+                @pulumi.runtime.test
+                def it_allows_http_ingress_on_port_80(http_ingress):
+                    return assert_output_equals(http_ingress.from_port, 80)
+
+                @pulumi.runtime.test
+                def it_allows_tls_ingress_from_sg(tls_ingress, sut):
+                    return assert_outputs_equal(tls_ingress.security_group_id, sut.alb.security_group.id)
+
+                @pulumi.runtime.test
+                def it_allows_http_ingress_from_sg(http_ingress, sut):
+                    return assert_outputs_equal(http_ingress.security_group_id, sut.alb.security_group.id)
+
+                @pulumi.runtime.test
+                def it_uses_tcp_for_tls_ingress(tls_ingress):
+                    return assert_output_equals(tls_ingress.protocol, "tcp")
+
+                @pulumi.runtime.test
+                def it_uses_tcp_for_http_ingress(http_ingress):
+                    return assert_output_equals(http_ingress.protocol, "tcp")
+
+                @pulumi.runtime.test
+                def it_uses_ingress_type_for_tls_ingress(tls_ingress):
+                    return assert_output_equals(tls_ingress.type, "ingress")
+
+                @pulumi.runtime.test
+                def it_uses_ingress_type_for_http_ingress(http_ingress):
+                    return assert_output_equals(http_ingress.type, "ingress")
+
+
         @pulumi.runtime.test
         def describe_the_fargate_service():
             @pulumi.runtime.test

--- a/deployment/src/tests/test_container.py
+++ b/deployment/src/tests/test_container.py
@@ -321,7 +321,7 @@ def describe_container():
             @pulumi.runtime.test
             def it_sets_the_access_log_bucket(sut, stack, app_name):
                 expected = {
-                    "bucket": "loadbalancer-logs-221871915463",
+                    "bucket": "loadbalancer-logs-None",
                     "enabled": True,
                     "prefix": f"{app_name}-{stack}",
                 }


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-3216)

## Purpose 
<!-- what/why -->
The way we were using the awsx component to create the load balancer caused a listener on port 3000 to get created which got hit by bots and resulted in 5xx errors on our load balancer that alarmed.

## Approach 
<!-- how -->
Instead of using the pulumi.awsx component to create the load balancer, we are switching to use the component created by the Caylent team. This removes the "default target group" that created a listener pointed at port 3000.

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
We tested this change by rolling it out to multiple projects including frozen desserts, repository dashboard, and canvas-alerts-api-rails. 

## Screenshots/Video
<!-- show before/after of the change if possible -->
Before

![image](https://github.com/user-attachments/assets/75009c40-77d6-46d0-aa9c-16a3e8d2ac58)


After

![image](https://github.com/user-attachments/assets/2592ff42-2874-404b-8892-92023a0c4b03)
![image](https://github.com/user-attachments/assets/ae300716-f44e-4487-a4fe-24c354b08af8)
