### PR TITLE
BEL-3521 Bring back desired_web_count

### DIFF
--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -57,6 +57,7 @@ class RailsComponent(pulumi.ComponentResource):
         :key db_username: The username for connecting to the app database. Defaults to project name and environment.
         :key worker_autoscale: Whether to autoscale the worker container. Defaults to False.
         :key db_engine_version: The version of the database engine. Defaults to 15.4.
+        :key desired_web_count: The number of instances of the web container to run. Defaults to 1.
         :key desired_worker_count: The number of instances of the worker container to run. Defaults to 1.
         :key rds_minimum_capacity: The minimum capacity of the RDS cluster. Defaults to 0.5.
         :key rds_maximum_capacity: The maximum capacity of the RDS cluster. Defaults to 16.
@@ -91,7 +92,7 @@ class RailsComponent(pulumi.ComponentResource):
         self.autoscale = self.kwargs.get('autoscale', True)
         self.worker_autoscale = self.kwargs.get('worker_autoscale', False)
         self.engine_version = self.kwargs.get('db_engine_version', '15.4')
-        self.desired_web_count = 2
+        self.desired_web_count = self.kwargs.get('desired_web_count', 1)
         self.desired_worker_count = self.kwargs.get('desired_worker_count', 1)
         self.rds_minimum_capacity = self.kwargs.get('rds_minimum_capacity', 0.5)
         self.rds_maximum_capacity = self.kwargs.get('rds_maximum_capacity', 16)

--- a/deployment/src/tests/mocks.py
+++ b/deployment/src/tests/mocks.py
@@ -27,6 +27,7 @@ def get_pulumi_mocks(faker, fake_password=None, secret_string="{}"):
                     }
                 outputs = {
                     **args.inputs,
+                    "desired_count": args.inputs["desiredCount"],
                     "task_definition_args": args.inputs["taskDefinitionArgs"],
                     "task_definition": TaskDefinitionMock(),
                     "propagate_tags": args.inputs.get("propagateTags"),

--- a/deployment/src/tests/test_rails.py
+++ b/deployment/src/tests/test_rails.py
@@ -617,6 +617,24 @@ def describe_a_pulumi_rails_component():
             ).apply(check_machine_specs)
 
         @pulumi.runtime.test
+        def it_sets_the_desired_web_count_to_a_default_of_one(sut):
+            return assert_output_equals(sut.web_container.fargate_service.desired_count, 1)
+
+        def describe_when_desired_web_count_is_provided():
+            @pytest.fixture
+            def desired_web_count(faker):
+                return faker.random_int()
+
+            @pytest.fixture
+            def component_kwargs(component_kwargs, desired_web_count):
+                component_kwargs['desired_web_count'] = desired_web_count
+                return component_kwargs
+
+            @pulumi.runtime.test
+            def it_sets_the_desired_web_count(sut, desired_web_count):
+                return assert_output_equals(sut.web_container.fargate_service.desired_count, desired_web_count)
+
+        @pulumi.runtime.test
         def it_uses_rails_entry_point(sut, container_entry_point):
             assert sut.web_container.entry_point == container_entry_point
 


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/TEAM-NUMBER)

## Purpose 
<!-- what/why -->
Central apparently doesn't run under load with only two containers.

## Approach 
<!-- how -->
Allow central to specify its web container count for now.

