### PR TITLE
BEL-3138 Fix autoscaling issues on creation.

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -313,7 +313,10 @@ class ContainerComponent(pulumi.ComponentResource):
         if self.kwargs.get('worker_autoscaling'):
             pulumi.log.info("WORKER AUTOSCALING ENABLED")
             self.worker_autoscaling = WorkerAutoscaleComponent("worker-autoscale",
-                                                               opts=pulumi.ResourceOptions(parent=self),
+                                                               opts=pulumi.ResourceOptions(
+                                                                   parent=self,
+                                                                   depends_on=[self.fargate_service]
+                                                               ),
                                                                **self.kwargs)
 
 
@@ -329,6 +332,9 @@ class ContainerComponent(pulumi.ComponentResource):
             resource_id=f"service/{self.project_stack}/{self.project_stack}",
             scalable_dimension="ecs:service:DesiredCount",
             service_namespace="ecs",
+            opts=pulumi.ResourceOptions(
+                depends_on=[self.fargate_service]
+            ),
         )
         self.autoscaling_out_policy = aws.appautoscaling.Policy(
             "autoscaling_out_policy",


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-3138)

## Purpose 
Deployment does not work the first time because it depends on the fargate service already being available to set an autoscaling target. This was not the case.

Folks were turning autoscaling off, and then turning it back on again in order to make this work.

## Approach 
Specifying the dependency order fixes this problem.

## Testing
Unable to do automated testing as Pulumi makes it impossible to test for dependency order through resource opts, so tested in staging enterprise canvas.