### PR TITLE
BEL-3138: Set REDIS_SERVER in the environment variable

### DIFF
--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -153,6 +153,7 @@ class RailsComponent(pulumi.ComponentResource):
 
             if self.cache_redis:
                 self.env_vars['CACHE_REDIS_URL'] = self.cache_redis.url
+                self.env_vars['REDIS_SERVER'] = self.cache_redis.url
 
     def security(self):
         self.firewall_rule = aws.ec2.SecurityGroupRule(

--- a/deployment/src/tests/test_rails.py
+++ b/deployment/src/tests/test_rails.py
@@ -775,6 +775,10 @@ def describe_a_pulumi_rails_component():
         def it_sends_the_url_to_the_ecs_environment(sut):
             return assert_outputs_equal(sut.env_vars["CACHE_REDIS_URL"], sut.cache_redis.url)
 
+        @pulumi.runtime.test
+        def it_sends_the_url_to_the_ecs_environment(sut):
+            return assert_outputs_equal(sut.env_vars["REDIS_SERVER"], sut.cache_redis.url)
+
     def describe_with_custom_cache_redis():
         @pytest.fixture
         def component_kwargs(component_kwargs):


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-3138)

## Purpose 
<!-- what/why -->
Enterprise Canvas doesn't have REDIS_SERVER in the env and it needs the env variable to work


## Approach 
<!-- how -->
Set the REDIS_SERVER env variable in rails.py

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
pytest
