### PR TITLE
BEL-3138: Change cname_record.value and cert_validation.value to .content

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -548,7 +548,7 @@ class ContainerComponent(pulumi.ComponentResource):
                 type='CNAME',
                 allow_overwrite=True,
                 zone_id=zone_id,
-                value=lb_dns_name,
+                content=lb_dns_name,
                 ttl=1,
                 opts=pulumi.ResourceOptions(parent=self),
             )
@@ -570,7 +570,7 @@ class ContainerComponent(pulumi.ComponentResource):
             name=domain_validation_options[0].resource_record_name,
             type=domain_validation_options[0].resource_record_type,
             zone_id=zone_id,
-            value=resource_record_value,
+            content=resource_record_value,
             ttl=1,
             opts=pulumi.ResourceOptions(parent=self, depends_on=[self.cert]),
         )

--- a/deployment/src/tests/test_container.py
+++ b/deployment/src/tests/test_container.py
@@ -644,7 +644,7 @@ def describe_container():
 
         @pulumi.runtime.test
         def it_points_to_load_balancer(sut, load_balancer_dns_name):
-            return assert_output_equals(sut.cname_record.value, load_balancer_dns_name)
+            return assert_output_equals(sut.cname_record.content, load_balancer_dns_name)
 
     def describe_cert():
         @pulumi.runtime.test
@@ -677,7 +677,7 @@ def describe_container():
 
         @pulumi.runtime.test
         def it_adds_validation_record_with_value(sut, resource_record_value):
-            return assert_output_equals(sut.cert_validation_record.value, resource_record_value)
+            return assert_output_equals(sut.cert_validation_record.content, resource_record_value)
 
         @pulumi.runtime.test
         def it_adds_validation_record_with_ttl(sut):


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-3138)

## Purpose 
<!-- what/why -->
Pulumi has deprecated .value and it's now changed to .content

## Approach 
<!-- how -->
Change .value to .content for cname_record and cert_validation

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
pytest
