### PR TITLE
Bel 3524 Deal with Pulumi Refresh Issue

### DIFF
--- a/.github/workflows/aws-deploy-with-pulumi.yml
+++ b/.github/workflows/aws-deploy-with-pulumi.yml
@@ -47,15 +47,14 @@ jobs:
       uses: aws-actions/amazon-ecr-login@v1
 
     - name: Set up Python
-      #if: ${{ inputs.pulumi-command == 'refresh' }}
+      if: ${{ inputs.pulumi-command == 'refresh' }}
       uses: actions/setup-python@v4
       with:
         python-version: '3.10'
 
     - name: Install dependencies
-      #if: ${{ inputs.pulumi-command == 'refresh' }}
+      if: ${{ inputs.pulumi-command == 'refresh' }}
       run: |
-        echo ${{ inputs.pulumi-command }}
         cd ./infrastructure/
         python -m venv venv
         source venv/bin/activate

--- a/.github/workflows/aws-deploy-with-pulumi.yml
+++ b/.github/workflows/aws-deploy-with-pulumi.yml
@@ -46,6 +46,21 @@ jobs:
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
 
+    - name: Set up Python
+      if: ${{ inputs.pulumi-command == 'refresh' }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: Install dependencies
+      if: ${{ inputs.pulumi-command == 'refresh' }}
+      run: |
+        cd ./infrastructure/
+        python -m venv venv
+        source venv/bin/activate
+        pip install -r requirements.txt  
+        cd ..
+
     - name: Deploy with Pulumi
       env:
         PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}

--- a/.github/workflows/aws-deploy-with-pulumi.yml
+++ b/.github/workflows/aws-deploy-with-pulumi.yml
@@ -47,14 +47,15 @@ jobs:
       uses: aws-actions/amazon-ecr-login@v1
 
     - name: Set up Python
-      if: ${{ inputs.pulumi-command == 'refresh' }}
+      #if: ${{ inputs.pulumi-command == 'refresh' }}
       uses: actions/setup-python@v4
       with:
         python-version: '3.10'
 
     - name: Install dependencies
-      if: ${{ inputs.pulumi-command == 'refresh' }}
+      #if: ${{ inputs.pulumi-command == 'refresh' }}
       run: |
+        echo ${{ inputs.pulumi-command }}
         cd ./infrastructure/
         python -m venv venv
         source venv/bin/activate

--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   deploy-auto:
     name: Autodeploy to ECS
-    uses: strongmind/public-reusable-workflows/.github/workflows/aws-deploy-with-pulumi.yml@main
+    uses: strongmind/public-reusable-workflows/.github/workflows/aws-deploy-with-pulumi.yml@bel-3524
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     with:
       environment-name: ${{ inputs.environment-name }}

--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -36,7 +36,7 @@ jobs:
 
   deploy-manual:
     name: Manually deploy to ECS
-    uses: strongmind/public-reusable-workflows/.github/workflows/aws-deploy-with-pulumi.yml@bel-3524
+    uses: strongmind/public-reusable-workflows/.github/workflows/aws-deploy-with-pulumi.yml@main
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.commit-sha == '' }}
     with:
       environment-name: ${{ inputs.environment-name }}

--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   deploy-auto:
     name: Autodeploy to ECS
-    uses: strongmind/public-reusable-workflows/.github/workflows/aws-deploy-with-pulumi.yml@bel-3524
+    uses: strongmind/public-reusable-workflows/.github/workflows/aws-deploy-with-pulumi.yml@main
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     with:
       environment-name: ${{ inputs.environment-name }}
@@ -36,7 +36,7 @@ jobs:
 
   deploy-manual:
     name: Manually deploy to ECS
-    uses: strongmind/public-reusable-workflows/.github/workflows/aws-deploy-with-pulumi.yml@main
+    uses: strongmind/public-reusable-workflows/.github/workflows/aws-deploy-with-pulumi.yml@bel-3524
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.commit-sha == '' }}
     with:
       environment-name: ${{ inputs.environment-name }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -40,15 +40,6 @@ permissions:
   contents: read
 
 jobs:
-  Verify-Plumi-Refresh:
-    name: Verify pulumi refresh
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: echo pulumi refresh
-        run: |
-          echo "PULUMI REFRESH== ${{ inputs.pulumi-refresh }}"
   pulumi-refresh:
     name: pulumi refresh
     uses: strongmind/public-reusable-workflows/.github/workflows/aws-deploy.yml@main
@@ -75,9 +66,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: '0'
-      - name: echo pulumi refresh
-        run: |
-          echo "PULUMI REFRESH== ${{ inputs.pulumi-refresh }}"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -52,7 +52,8 @@ jobs:
   pulumi-refresh:
     name: pulumi refresh
     uses: strongmind/public-reusable-workflows/.github/workflows/aws-deploy.yml@bel-3524
-    if: ${{ inputs.pulumi-refresh == 'true' }}
+    if: ${{ (github.event.workflow_run.conclusion == 'success' || github.event_name
+      == 'workflow_dispatch' ) && inputs.pulumi-refresh == 'true' }}
     with:
       environment-name: prod
       pulumi-command: refresh

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -51,7 +51,7 @@ jobs:
           echo "PULUMI REFRESH== ${{ inputs.pulumi-refresh }}"
   pulumi-refresh:
     name: pulumi refresh
-    uses: strongmind/public-reusable-workflows/.github/workflows/aws-deploy.yml@bel-3524
+    uses: strongmind/public-reusable-workflows/.github/workflows/aws-deploy.yml@main
     if: ${{ (github.event.workflow_run.conclusion == 'success' || github.event_name
       == 'workflow_dispatch' ) && inputs.pulumi-refresh == 'true' }}
     with:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -40,6 +40,15 @@ permissions:
   contents: read
 
 jobs:
+  Verify-Plumi-Refresh:
+    name: Verify pulumi refresh
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: echo pulumi refresh
+        run: |
+          echo "PULUMI REFRESH== ${{ inputs.pulumi-refresh }}"
   pulumi-refresh:
     name: pulumi refresh
     uses: strongmind/public-reusable-workflows/.github/workflows/aws-deploy.yml@bel-3524

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -41,14 +41,19 @@ permissions:
 
 jobs:
   pulumi-refresh:
-    name: pulumi refresh
-    uses: strongmind/public-reusable-workflows/.github/workflows/aws-deploy.yml@bel-3524
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name
-      == 'workflow_dispatch' }} && ${{ inputs.pulumi-refresh == 'true' }}
-    with:
-      environment-name: prod
-      pulumi-command: refresh
-    secrets: inherit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo
+        run: echo "Pulumi refresh==" ${{ inputs.pulumi-refresh }}
+
+      - name: pulumi refresh
+        uses: strongmind/public-reusable-workflows/.github/workflows/aws-deploy.yml@bel-3524
+        if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name
+          == 'workflow_dispatch' }} && ${{ inputs.pulumi-refresh == 'true' }}
+        with:
+          environment-name: prod
+          pulumi-command: refresh
+        secrets: inherit
 
   test-docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -28,6 +28,10 @@ on:
         required: false
         type: string
         default: "3.2.2"
+      pulumi-refresh:
+        required: false
+        type: string
+        default: 'true'
 
 env:
   AWS_REGION: us-west-2
@@ -36,6 +40,16 @@ permissions:
   contents: read
 
 jobs:
+  pulumi-refresh:
+    name: pulumi refresh
+    uses: strongmind/public-reusable-workflows/.github/workflows/aws-deploy.yml@main
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name
+      == 'workflow_dispatch' }} && ${{ inputs.pulumi-refresh == 'true' }}
+    with:
+      environment-name: prod
+      pulumi-command: refresh
+    secrets: inherit
+
   test-docker:
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -66,6 +66,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: '0'
+      - name: echo pulumi refresh
         run: |
           echo "PULUMI REFRESH== ${{ inputs.pulumi-refresh }}"
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -52,8 +52,7 @@ jobs:
   pulumi-refresh:
     name: pulumi refresh
     uses: strongmind/public-reusable-workflows/.github/workflows/aws-deploy.yml@bel-3524
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name
-      == 'workflow_dispatch' }} && ${{ inputs.pulumi-refresh == 'true' }}
+    if: ${{ inputs.pulumi-refresh == 'true' }}
     with:
       environment-name: prod
       pulumi-command: refresh

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -41,19 +41,14 @@ permissions:
 
 jobs:
   pulumi-refresh:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Echo
-        run: echo "Pulumi refresh==" ${{ inputs.pulumi-refresh }}
-
-      - name: pulumi refresh
-        uses: strongmind/public-reusable-workflows/.github/workflows/aws-deploy.yml@bel-3524
-        if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name
-          == 'workflow_dispatch' }} && ${{ inputs.pulumi-refresh == 'true' }}
-        with:
-          environment-name: prod
-          pulumi-command: refresh
-        secrets: inherit
+    name: pulumi refresh
+    uses: strongmind/public-reusable-workflows/.github/workflows/aws-deploy.yml@bel-3524
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name
+      == 'workflow_dispatch' }} && ${{ inputs.pulumi-refresh == 'true' }}
+    with:
+      environment-name: prod
+      pulumi-command: refresh
+    secrets: inherit
 
   test-docker:
     runs-on: ubuntu-latest
@@ -71,6 +66,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: '0'
+        run: |
+          echo "PULUMI REFRESH== ${{ inputs.pulumi-refresh }}"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -42,7 +42,7 @@ permissions:
 jobs:
   pulumi-refresh:
     name: pulumi refresh
-    uses: strongmind/public-reusable-workflows/.github/workflows/aws-deploy.yml@main
+    uses: strongmind/public-reusable-workflows/.github/workflows/aws-deploy.yml@bel-3524
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name
       == 'workflow_dispatch' }} && ${{ inputs.pulumi-refresh == 'true' }}
     with:


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/bel-3524)

## Purpose 
<!-- what/why -->
Keep pulumi state file in sync with prod
## Approach 
<!-- how -->
Run pulumi refresh during docker build.
Allow to temporarily bypass pulumi refresh with a pulumi-refresh input bool.
Can still pulumi refresh stage env at any time using pulumi-command in a stage deploy.
## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Called dev branch of prw using repo-dashboard and verified refresh ran during docker build and did not run when `pulumi-refresh: 'false'` was added to build.yml build job. 

