### PR TITLE
BEL-3138: Protect DynamoDB and S3 Bucket

### DIFF
--- a/deployment/src/strongmind_deployment/dynamo.py
+++ b/deployment/src/strongmind_deployment/dynamo.py
@@ -19,7 +19,9 @@ class DynamoComponent(pulumi.ComponentResource):
         stack = pulumi.get_stack()
         table_opts = ResourceOptions(
             parent=self,
-            ignore_changes=["read_capacity", "write_capacity"])  # pragma: no cover
+            ignore_changes=["read_capacity", "write_capacity"],
+            protect=True
+        )  # pragma: no cover
         hash_key = kwargs.get("hash_key")
         if not hash_key:
             raise ValueError("hash_key is required")

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -368,7 +368,7 @@ class RailsComponent(pulumi.ComponentResource):
 
     def setup_storage(self):
         self.storage = StorageComponent("storage",
-                                        pulumi.ResourceOptions(parent=self),
+                                        pulumi.ResourceOptions(parent=self, protect=True),
                                         **self.kwargs
                                         )
         self.env_vars.update(self.storage.s3_env_vars)


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-3138)

## Purpose 
<!-- what/why -->
When bringing down canvas-stage, it would try to delete DynamoDB and S3 bucket. However, these resources should be protected to avoid data loss.

## Approach 
<!-- how -->
Add protect=True for the resources