### PR TITLE
BEL-3386: Create a venv when running pulumi down.

### DIFF
--- a/.github/workflows/aws-deploy-with-pulumi.yml
+++ b/.github/workflows/aws-deploy-with-pulumi.yml
@@ -47,13 +47,13 @@ jobs:
       uses: aws-actions/amazon-ecr-login@v1
 
     - name: Set up Python
-      if: ${{ inputs.pulumi-command == 'refresh' }}
+      if: ${{ inputs.pulumi-command == 'refresh' ||  inputs.pulumi-command == 'down' }}
       uses: actions/setup-python@v4
       with:
         python-version: '3.10'
 
     - name: Install dependencies
-      if: ${{ inputs.pulumi-command == 'refresh' }}
+      if: ${{ inputs.pulumi-command == 'refresh' ||  inputs.pulumi-command == 'down' }}
       run: |
         cd ./infrastructure/
         python -m venv venv


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-3386)

## Purpose 
<!-- what/why -->
- Running pulumi down from a github workflow causes it to error out as there is no VENV created.