### PR TITLE
BEL-3386: Refresh pulumi stage when running docker build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -40,13 +40,21 @@ permissions:
   contents: read
 
 jobs:
-  pulumi-refresh:
-    name: pulumi refresh
+  pulumi-refresh-prod:
+    name: pulumi refresh on prod
     uses: strongmind/public-reusable-workflows/.github/workflows/aws-deploy.yml@main
-    if: ${{ (github.event.workflow_run.conclusion == 'success' || github.event_name
-      == 'workflow_dispatch' ) && inputs.pulumi-refresh == 'true' }}
+    if: ${{ inputs.pulumi-refresh == 'true' }}
     with:
       environment-name: prod
+      pulumi-command: refresh
+    secrets: inherit
+
+  pulumi-refresh-stage:
+    name: pulumi refresh on stage
+    uses: strongmind/public-reusable-workflows/.github/workflows/aws-deploy.yml@main
+    if: ${{ inputs.pulumi-refresh == 'true' }}
+    with:
+      environment-name: stage
       pulumi-command: refresh
     secrets: inherit
 


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-3386)

## Purpose 
<!-- what/why -->
We want to make it easier for devs to delete infrastructure if needed. We are refreshing stage in case the developer deletes protected resources manually in AWS.

## Approach 
<!-- how -->
Create a new job to refresh pulumi stage

