### PR TITLE
Fix AlbArgs to allow subnets to be optional with a default of none

### DIFF
--- a/deployment/src/strongmind_deployment/alb.py
+++ b/deployment/src/strongmind_deployment/alb.py
@@ -29,8 +29,8 @@ class AlbArgs:
     def __init__(
         self,
         vpc_id: str,
-        subnets: Sequence[str],
         certificate_arn: str,
+        subnets: Sequence[str] = None,
         placement: Optional[AlbPlacement] = AlbPlacement.EXTERNAL,
         internal_ingress_cidrs: list[str] = [],
         ingress_sg: ec2.SecurityGroup = None,


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/TEAM-NUMBER)

## Purpose 
<!-- what/why -->
Fix the alb component b/c recent changes broke identity deploy
## Approach 
<!-- how -->
Fix AlbArgs to allow subnets to be optional with a default of none
## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
No tests yet
