### PR TITLE
Change the Namespace for the Running Task Alarm

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -419,7 +419,7 @@ class ContainerComponent(pulumi.ComponentResource):
             comparison_operator="GreaterThanThreshold",
             evaluation_periods=1,
             metric_name="RunningTaskCount",
-            namespace="AWS/ECS",
+            namespace="ECS/ContainerInsights",
             dimensions={
                 "ClusterName": self.project_stack,
                 "ServiceName": self.project_stack


### PR DESCRIPTION
## Purpose 
<!-- what/why -->
Running task alarm is not reporting the runningtaskcount metric
## Approach 
<!-- how -->
Change the Namespace for the Running Task Alarm

Verified by pushing pulumi locally on repo dash
![image](https://github.com/user-attachments/assets/3ef892e5-d4f7-448d-9907-e45b39c7262e)
