### PR TITLE
Update python-package-build.yml

### DIFF
--- a/.github/workflows/python-package-build.yml
+++ b/.github/workflows/python-package-build.yml
@@ -36,7 +36,7 @@ jobs:
         cd .. && make build 
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ github.sha }}
         path: 'dist/*'


### PR DESCRIPTION
## Purpose 
<!-- what/why -->
Merges are failing due to Upload Artifact being deprecated

## Approach 
<!-- how -->
Use v4 of Upload Artifacts as the older versions are deprecated
