### PR TITLE
Bel 3198 Route All Load Balancer Alarms to Teams

### DIFF
--- a/deployment/src/strongmind_deployment/alb.py
+++ b/deployment/src/strongmind_deployment/alb.py
@@ -35,6 +35,7 @@ class AlbArgs:
         internal_ingress_cidrs: list[str] = [],
         ingress_sg: ec2.SecurityGroup = None,
         should_protect: bool = False,
+        tags: dict = None,
     ):
         self.vpc_id = vpc_id
         self.subnets = subnets
@@ -43,6 +44,7 @@ class AlbArgs:
         self.internal_ingress_cidrs = internal_ingress_cidrs
         self.ingress_sg = ingress_sg
         self.should_protect = should_protect
+        self.tags = tags
 
 
 class Alb(pulumi.ComponentResource):
@@ -69,6 +71,7 @@ class Alb(pulumi.ComponentResource):
         stack = pulumi.get_stack()
         project = pulumi.get_project()[:18]
         self.project_stack = f"{project}-{stack}"
+        self.tags = args.tags or {}
 
 
         self.child_opts = pulumi.ResourceOptions(parent=self)
@@ -120,6 +123,7 @@ class Alb(pulumi.ComponentResource):
                 prefix=self.project_stack,
                 enabled=True,
             ),
+            tags=self.tags,
             opts=self.child_opts,
         )
         return alb

--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -505,6 +505,7 @@ class ContainerComponent(pulumi.ComponentResource):
             subnets=default_vpc.public_subnet_ids,
             placement=alb.AlbPlacement.EXTERNAL,
             certificate_arn=self.cert.arn,
+            tags=self.tags,
         )
         self.alb = alb.Alb("loadbalancer", alb_args)
         self.load_balancer = self.alb.alb

--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -13,6 +13,7 @@ from pulumi_cloudflare import get_zone, Record
 from strongmind_deployment import alb
 from strongmind_deployment.autoscale import WorkerAutoscaleComponent
 from strongmind_deployment.util import create_ecs_cluster
+from strongmind_deployment import operations
 
 class ContainerComponent(pulumi.ComponentResource):
     def __init__(self, name, opts=None, **kwargs):
@@ -65,10 +66,8 @@ class ContainerComponent(pulumi.ComponentResource):
         self.desired_count = kwargs.get('desired_count', 2)
         self.max_capacity = 100
         self.min_capacity = self.desired_count
-        self.sns_topic_arn = kwargs.get('sns_topic_arn', 'arn:aws:sns:us-west-2:221871915463:DevOps-Opsgenie')
+        self.sns_topic_arn = operations.get_opsgenie_sns_topic_arn() or 'arn:aws:sns:us-west-2:221871915463:DevOps-Opsgenie'
 
-        if stack.lower() == 'stage':
-            self.sns_topic_arn = 'arn:aws:sns:us-west-2:221871915463:DevOps-Opsgenie-Stage'
 
         project = pulumi.get_project()
         self.project_stack = f"{project}-{stack}"

--- a/deployment/src/tests/mocks.py
+++ b/deployment/src/tests/mocks.py
@@ -130,6 +130,9 @@ def get_pulumi_mocks(faker, fake_password=None, secret_string="{}"):
             return [args.name + '_id', outputs]
 
         def call(self, args: pulumi.runtime.MockCallArgs):
+            if args.token == "aws:index/getRegion:getRegion":
+                return {"name": "us-west-2"}
+
             if args.token == "aws:secretsmanager/getSecretVersion:getSecretVersion":
                 return {
                     "arn": f"arn:aws:secretsmanager:us-west-2:123456789013:secret/my-secrets",


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/bel-3198)

## Purpose 
<!-- what/why -->
Route All Load Balancer Alarms to Teams
## Approach 
<!-- how -->
Add tags to alb component b/c new load balancers are not tagged
Use the operations.py file to get sns_topic_arn
## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Ran pulumi locally on repo-dashboard
## Screenshots/Video
<!-- show before/after of the change if possible -->
Add tags to LB:
![image](https://github.com/user-attachments/assets/7fa96b81-4891-40ce-a691-5470469afdd1)
Route to team based on owning team:
![image](https://github.com/user-attachments/assets/c9da2c95-b3ae-4649-8078-ebd4b25fd44d)
