### PR TITLE
Bel-4020 Update Web Autoscaling Alarms to use Target Response Time as the Metric

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -356,6 +356,12 @@ class ContainerComponent(pulumi.ComponentResource):
                 ],
             )
         )
+        target_group_dimension = self.target_group.arn.apply(
+            lambda arn: arn.split(":")[-1]
+        )
+        load_balancer_arn = self.load_balancer.arn.apply(
+            lambda arn: arn.split("/", 1)[1]
+        )
         self.autoscaling_out_alarm = aws.cloudwatch.MetricAlarm(
             "autoscaling_alarm",
             name=f"{self.project_stack}-auto-scaling-out-alarm",
@@ -366,8 +372,8 @@ class ContainerComponent(pulumi.ComponentResource):
             namespace="AWS/ApplicationELB",
             extended_statistic="p99",
             dimensions={
-                "TargetGroup": f"{self.target_group.arn}",
-                "LoadBalancer": f"{self.load_balancer.arn}",
+                "TargetGroup": target_group_dimension,
+                "LoadBalancer": load_balancer_arn,
             },
             period=60,
             evaluation_periods=1,
@@ -385,7 +391,7 @@ class ContainerComponent(pulumi.ComponentResource):
             service_namespace=self.autoscaling_target.service_namespace,
             step_scaling_policy_configuration=aws.appautoscaling.PolicyStepScalingPolicyConfigurationArgs(
                 adjustment_type="ChangeInCapacity",
-                cooldown=900,
+                cooldown=300,
                 metric_aggregation_type="Maximum",
                 step_adjustments=[
                     aws.appautoscaling.PolicyStepScalingPolicyConfigurationStepAdjustmentArgs(
@@ -398,49 +404,21 @@ class ContainerComponent(pulumi.ComponentResource):
         self.autoscaling_in_alarm = aws.cloudwatch.MetricAlarm(
             "autoscaling_in_alarm",
             name=f"{self.project_stack}-auto-scaling-in-alarm",
-            comparison_operator="LessThanOrEqualToThreshold",
+            comparison_operator="LessThanThreshold",
             actions_enabled=True,
             alarm_actions=[self.autoscaling_in_policy.arn],
             evaluation_periods=5,
             datapoints_to_alarm=1,
-            threshold=35,
+            threshold=5,
             treat_missing_data="missing",
-            metric_queries=[
-                aws.cloudwatch.MetricAlarmMetricQueryArgs(
-                    id="e1",
-                    label="Expression1",
-                    return_data=True,
-                    expression="100*(m1/m2)",
-                ),
-                aws.cloudwatch.MetricAlarmMetricQueryArgs(
-                    id="m1",
-                    return_data=False,
-                    metric=aws.cloudwatch.MetricAlarmMetricQueryMetricArgs(
-                        namespace="ECS/ContainerInsights",
-                        metric_name="CpuUtilized",
-                        dimensions={
-                            "ClusterName": self.project_stack,
-                            "ServiceName": self.project_stack
-                        },
-                        period=60,
-                        stat="p99",
-                    ),
-                ),
-                aws.cloudwatch.MetricAlarmMetricQueryArgs(
-                    id="m2",
-                    return_data=False,
-                    metric=aws.cloudwatch.MetricAlarmMetricQueryMetricArgs(
-                        namespace="ECS/ContainerInsights",
-                        metric_name="CpuReserved",
-                        dimensions={
-                            "ServiceName": self.project_stack,
-                            "ClusterName": self.project_stack,
-                        },
-                        period=60,
-                        stat="p99",
-                    ),
-                ),
-            ],
+            metric_name="TargetResponseTime",
+            namespace="AWS/ApplicationELB",
+            extended_statistic="p99",
+            dimensions={
+                "TargetGroup": target_group_dimension,
+                "LoadBalancer": load_balancer_arn,
+            },
+            period=60,
         )
 
         self.running_tasks_alarm = aws.cloudwatch.MetricAlarm(

--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -367,40 +367,7 @@ class ContainerComponent(pulumi.ComponentResource):
             threshold=50,
             treat_missing_data="missing",
             metric_queries=[
-                aws.cloudwatch.MetricAlarmMetricQueryArgs(
-                    id="e1",
-                    label="Expression1",
-                    return_data=True,
-                    expression="100*(m1/m2)",
-                ),
-                aws.cloudwatch.MetricAlarmMetricQueryArgs(
-                    id="m1",
-                    return_data=False,
-                    metric=aws.cloudwatch.MetricAlarmMetricQueryMetricArgs(
-                        namespace="ECS/ContainerInsights",
-                        metric_name="CpuUtilized",
-                        dimensions={
-                            "ClusterName": self.project_stack,
-                            "ServiceName": self.project_stack
-                        },
-                        period=60,
-                        stat="p99",
-                    ),
-                ),
-                aws.cloudwatch.MetricAlarmMetricQueryArgs(
-                    id="m2",
-                    return_data=False,
-                    metric=aws.cloudwatch.MetricAlarmMetricQueryMetricArgs(
-                        namespace="ECS/ContainerInsights",
-                        metric_name="CpuReserved",
-                        dimensions={
-                            "ServiceName": self.project_stack,
-                            "ClusterName": self.project_stack,
-                        },
-                        period=60,
-                        stat="p99",
-                    ),
-                )
+
             ],
         )
         self.autoscaling_in_policy = aws.appautoscaling.Policy(

--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -362,14 +362,20 @@ class ContainerComponent(pulumi.ComponentResource):
             comparison_operator="GreaterThanOrEqualToThreshold",
             actions_enabled=True,
             alarm_actions=[self.autoscaling_out_policy.arn],
+            metric_name="TargetResponseTime",
+            namespace="AWS/ApplicationELB",
+            extended_statistic="p99",
+            dimensions={
+                "TargetGroup": f"{self.target_group.arn}",
+                "LoadBalancer": f"{self.load_balancer.arn}",
+            },
+            period=60,
             evaluation_periods=1,
             datapoints_to_alarm=1,
-            threshold=50,
-            treat_missing_data="missing",
-            metric_queries=[
-
-            ],
+            threshold=5,
+            treat_missing_data="missing"
         )
+
         self.autoscaling_in_policy = aws.appautoscaling.Policy(
             "autoscaling_in_policy",
             name=f"{self.project_stack}-autoscaling-in-policy",

--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -379,7 +379,8 @@ class ContainerComponent(pulumi.ComponentResource):
             evaluation_periods=1,
             datapoints_to_alarm=1,
             threshold=5,
-            treat_missing_data="missing"
+            treat_missing_data="missing",
+            tags=self.tags
         )
 
         self.autoscaling_in_policy = aws.appautoscaling.Policy(
@@ -419,6 +420,7 @@ class ContainerComponent(pulumi.ComponentResource):
                 "LoadBalancer": load_balancer_arn,
             },
             period=60,
+            tags=self.tags
         )
 
         self.running_tasks_alarm = aws.cloudwatch.MetricAlarm(

--- a/deployment/src/tests/mocks.py
+++ b/deployment/src/tests/mocks.py
@@ -121,7 +121,7 @@ def get_pulumi_mocks(faker, fake_password=None, secret_string="{}"):
             if args.typ == "aws:lb/loadBalancer:LoadBalancer":
                 outputs = {
                     **args.inputs,
-                    "arn": f"arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/{faker.word()}",
+                    "arn": f"arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/{faker.word()}",
                     "name": f"loadbalancer-{faker.word()}",
                 }
 

--- a/deployment/src/tests/test_container_autoscaling.py
+++ b/deployment/src/tests/test_container_autoscaling.py
@@ -147,6 +147,10 @@ def describe_autoscaling():
             def it_treats_missing_data_as_missing(sut):
                 return assert_output_equals(sut.autoscaling_out_alarm.treat_missing_data, "missing")
 
+            @pulumi.runtime.test
+            def it_has_tags(sut):
+                assert sut.autoscaling_out_alarm.tags
+
         def describe_autoscaling_in_alarm():
             @pulumi.runtime.test
             def it_exists(sut):
@@ -217,6 +221,10 @@ def describe_autoscaling():
             @pulumi.runtime.test
             def it_treats_missing_data_as_missing(sut):
                 return assert_output_equals(sut.autoscaling_in_alarm.treat_missing_data, "missing")
+
+            @pulumi.runtime.test
+            def it_has_tags(sut):
+                assert sut.autoscaling_in_alarm.tags
 
         def describe_autoscaling_in_policy():
             def it_exists(sut):

--- a/deployment/src/tests/test_container_autoscaling.py
+++ b/deployment/src/tests/test_container_autoscaling.py
@@ -13,6 +13,7 @@ def describe_autoscaling():
         def component_kwargs(component_kwargs):
             component_kwargs["autoscale"] = True
             return component_kwargs
+
         @pulumi.runtime.test
         def it_has_an_autoscaling_target(sut):
             assert sut.autoscaling_target
@@ -82,57 +83,72 @@ def describe_autoscaling():
 
             @pulumi.runtime.test
             def it_is_named_auto_scaling_out_alarm(sut, app_name, stack):
-                return assert_output_equals(sut.autoscaling_out_alarm.name, f"{app_name}-{stack}-auto-scaling-out-alarm")
+                return assert_output_equals(sut.autoscaling_out_alarm.name,
+                                            f"{app_name}-{stack}-auto-scaling-out-alarm")
 
             @pulumi.runtime.test
             def it_triggers_when_greater_than_or_equal_to_threshold(sut):
-                return assert_output_equals(sut.autoscaling_out_alarm.comparison_operator, "GreaterThanOrEqualToThreshold")
-
-            @pulumi.runtime.test
-            def it_evaluates_for_one_period(sut):
-                return assert_output_equals(sut.autoscaling_out_alarm.evaluation_periods, 1)
-
-            # @pulumi.runtime.test
-            # def it_triggers_based_on_mathematical_expression(sut):
-            #     return assert_output_equals(sut.autoscaling_out_alarm.metric_queries[0].expression, "100*(m1/m2)")
-            @pulumi.runtime.test
-            def it_triggers_based_on_the_response_time(sut):
-                return assert_output_equals(sut.autoscaling_out_alarm.metric_queries[0].metric.name,
-                                            "TargetResponseTime")
-
-            @pulumi.runtime.test
-            def it_checks_the_unit_as_a_p99(sut):
-                return assert_output_equals(sut.autoscaling_out_alarm.metric_queries[0].metric.stat, "p99")
-
-            @pulumi.runtime.test
-            def it_pulls_the_metric_data_from_the_target_group(sut):
-                arn_segment = sut.target_group.arn.apply(lambda arn: arn.split(":")[-1])
-
-                return assert_outputs_equal(
-                    sut.autoscaling_out_alarm.dimensions["TargetGroup"], arn_segment)
-
-            @pulumi.runtime.test
-            def it_pulls_the_metric_data_from_the_loadbalancer(sut):
-                arn_segment = sut.load_balancer.arn.apply(lambda arn: arn.split(":")[-1])
-                return assert_outputs_equal(sut.autoscaling_out_alarm.dimensions["LoadBalancer"], arn_segment)
-
-            @pulumi.runtime.test
-            def it_belongs_to_the_ECS_namespace(sut):
-                return assert_output_equals(sut.autoscaling_out_alarm.metric_queries[1].metric.namespace, "ECS/ContainerInsights")
-
-            @pulumi.runtime.test
-            def it_runs_every_minute(sut):
-                return assert_output_equals(sut.autoscaling_out_alarm.metric_queries[1].metric.period, 60)
-
-            @pulumi.runtime.test
-            def it_triggers_when_the_threshold_crosses_50(sut):
-                return assert_output_equals(sut.autoscaling_out_alarm.threshold, 50)
+                return assert_output_equals(sut.autoscaling_out_alarm.comparison_operator,
+                                            "GreaterThanOrEqualToThreshold")
 
             @pulumi.runtime.test
             def it_triggers_the_autoscaling_policy(sut):
                 return assert_outputs_equal(sut.autoscaling_out_alarm.alarm_actions, [sut.autoscaling_out_policy.arn])
 
+            @pulumi.runtime.test
+            def it_triggers_based_on_the_response_time(sut):
+                return assert_output_equals(sut.autoscaling_out_alarm.metric_name,
+                                            "TargetResponseTime")
+
+            @pulumi.runtime.test
+            def it_belongs_to_the_AWS_namespace(sut):
+                return assert_output_equals(sut.autoscaling_out_alarm.namespace,
+                                            "AWS/ApplicationELB")
+
+            @pulumi.runtime.test
+            def it_checks_the_unit_as_a_p99(sut):
+                return assert_output_equals(sut.autoscaling_out_alarm.extended_statistic, "p99")
+
+            @pulumi.runtime.test
+            def it_pulls_the_metric_data_from_the_target_group(sut):
+                def check_target_group_dimension(args):
+                    target_group_arn, dimensions_target_group = args
+                    target_group_arn = target_group_arn.split(":")[-1]
+                    assert target_group_arn == dimensions_target_group
+
+                return pulumi.Output.all(sut.target_group.arn,
+                                         sut.autoscaling_out_alarm.dimensions['TargetGroup']).apply(
+                    check_target_group_dimension)
+
+            @pulumi.runtime.test
+            def it_pulls_the_metric_data_from_the_loadbalancer(sut):
+                def check_loadbalancer_dimension(args):
+                    loadbalancer_arn, dimensions_loadbalancer = args
+                    loadbalancer_arn = loadbalancer_arn.split("/", 1)[1]
+                    assert loadbalancer_arn == dimensions_loadbalancer
+
+                return pulumi.Output.all(sut.load_balancer.arn,
+                                         sut.autoscaling_out_alarm.dimensions['LoadBalancer']).apply(
+                    check_loadbalancer_dimension)
+
+            @pulumi.runtime.test
+            def it_runs_every_minute(sut):
+                return assert_output_equals(sut.autoscaling_out_alarm.period, 60)
+
+            @pulumi.runtime.test
+            def it_evaluates_for_one_period(sut):
+                return assert_output_equals(sut.autoscaling_out_alarm.evaluation_periods, 1)
+
+            @pulumi.runtime.test
+            def it_triggers_when_the_threshold_crosses_5(sut):
+                return assert_output_equals(sut.autoscaling_out_alarm.threshold, 5)
+
+            @pulumi.runtime.test
+            def it_treats_missing_data_as_missing(sut):
+                return assert_output_equals(sut.autoscaling_out_alarm.treat_missing_data, "missing")
+
         def describe_autoscaling_in_alarm():
+            @pulumi.runtime.test
             def it_exists(sut):
                 assert sut.autoscaling_in_alarm
 
@@ -142,44 +158,65 @@ def describe_autoscaling():
                                             f"{app_name}-{stack}-auto-scaling-in-alarm")
 
             @pulumi.runtime.test
-            def it_triggers_when_less_than_or_equal_to_threshold(sut):
-                return assert_output_equals(sut.autoscaling_in_alarm.comparison_operator, "LessThanOrEqualToThreshold")
-
-            @pulumi.runtime.test
-            def it_evaluates_for_five_periods(sut):
-                return assert_output_equals(sut.autoscaling_in_alarm.evaluation_periods, 5)
-
-            @pulumi.runtime.test
-            def it_triggers_based_on_mathematical_expression(sut):
-                return assert_output_equals(sut.autoscaling_in_alarm.metric_queries[0].expression, "100*(m1/m2)")
-
-            @pulumi.runtime.test
-            def it_checks_the_unit_as_a_p99(sut):
-                return assert_output_equals(sut.autoscaling_in_alarm.metric_queries[1].metric.stat, "p99")
-
-            @pulumi.runtime.test
-            def it_pulls_the_metric_data_from_the_cluster(sut):
-                return assert_output_equals(sut.autoscaling_in_alarm.metric_queries[1].metric.dimensions["ClusterName"], sut.project_stack)
-
-            @pulumi.runtime.test
-            def it_pulls_the_metric_data_from_the_service(sut):
-                return assert_output_equals(sut.autoscaling_in_alarm.metric_queries[1].metric.dimensions["ServiceName"], sut.project_stack)
-
-            @pulumi.runtime.test
-            def it_belongs_to_the_ECS_namespace(sut):
-                return assert_output_equals(sut.autoscaling_in_alarm.metric_queries[1].metric.namespace, "ECS/ContainerInsights")
-
-            @pulumi.runtime.test
-            def it_runs_every_minute(sut):
-                return assert_output_equals(sut.autoscaling_in_alarm.metric_queries[1].metric.period, 60)
-
-            @pulumi.runtime.test
-            def it_triggers_when_the_threshold_fall_below_35(sut):
-                return assert_output_equals(sut.autoscaling_in_alarm.threshold, 35)
+            def it_triggers_when_greater_than_or_equal_to_threshold(sut):
+                return assert_output_equals(sut.autoscaling_in_alarm.comparison_operator,
+                                            "LessThanThreshold")
 
             @pulumi.runtime.test
             def it_triggers_the_autoscaling_policy(sut):
                 return assert_outputs_equal(sut.autoscaling_in_alarm.alarm_actions, [sut.autoscaling_in_policy.arn])
+
+            @pulumi.runtime.test
+            def it_triggers_based_on_the_response_time(sut):
+                return assert_output_equals(sut.autoscaling_in_alarm.metric_name,
+                                            "TargetResponseTime")
+
+            @pulumi.runtime.test
+            def it_belongs_to_the_AWS_namespace(sut):
+                return assert_output_equals(sut.autoscaling_in_alarm.namespace,
+                                            "AWS/ApplicationELB")
+
+            @pulumi.runtime.test
+            def it_checks_the_unit_as_a_p99(sut):
+                return assert_output_equals(sut.autoscaling_in_alarm.extended_statistic, "p99")
+
+            @pulumi.runtime.test
+            def it_pulls_the_metric_data_from_the_target_group(sut):
+                def check_target_group_dimension(args):
+                    target_group_arn, dimensions_target_group = args
+                    target_group_arn = target_group_arn.split(":")[-1]
+                    assert target_group_arn == dimensions_target_group
+
+                return pulumi.Output.all(sut.target_group.arn,
+                                         sut.autoscaling_in_alarm.dimensions['TargetGroup']).apply(
+                    check_target_group_dimension)
+
+            @pulumi.runtime.test
+            def it_pulls_the_metric_data_from_the_loadbalancer(sut):
+                def check_loadbalancer_dimension(args):
+                    loadbalancer_arn, dimensions_loadbalancer = args
+                    loadbalancer_arn = loadbalancer_arn.split("/", 1)[1]
+                    assert loadbalancer_arn == dimensions_loadbalancer
+
+                return pulumi.Output.all(sut.load_balancer.arn,
+                                         sut.autoscaling_in_alarm.dimensions['LoadBalancer']).apply(
+                    check_loadbalancer_dimension)
+
+            @pulumi.runtime.test
+            def it_runs_every_minute(sut):
+                return assert_output_equals(sut.autoscaling_in_alarm.period, 60)
+
+            @pulumi.runtime.test
+            def it_evaluates_for_5_periods(sut):
+                return assert_output_equals(sut.autoscaling_in_alarm.evaluation_periods, 5)
+
+            @pulumi.runtime.test
+            def it_triggers_when_the_threshold_crosses_5(sut):
+                return assert_output_equals(sut.autoscaling_in_alarm.threshold, 5)
+
+            @pulumi.runtime.test
+            def it_treats_missing_data_as_missing(sut):
+                return assert_output_equals(sut.autoscaling_in_alarm.treat_missing_data, "missing")
 
         def describe_autoscaling_in_policy():
             def it_exists(sut):
@@ -212,7 +249,7 @@ def describe_autoscaling():
 
             @pulumi.runtime.test
             def it_has_a_default_cooldown(sut):
-                return assert_output_equals(sut.autoscaling_in_policy.step_scaling_policy_configuration.cooldown, 900)
+                return assert_output_equals(sut.autoscaling_in_policy.step_scaling_policy_configuration.cooldown, 300)
 
             @pulumi.runtime.test
             def it_changes_capacity(sut):
@@ -282,8 +319,9 @@ def describe_autoscaling():
 
             @pulumi.runtime.test
             def it_changes_capacity(sut):
-                return assert_output_equals(sut.autoscaling_out_policy.step_scaling_policy_configuration.adjustment_type,
-                                            "ChangeInCapacity")
+                return assert_output_equals(
+                    sut.autoscaling_out_policy.step_scaling_policy_configuration.adjustment_type,
+                    "ChangeInCapacity")
 
             @pulumi.runtime.test
             def it_has_a_default_maximum_metric_aggregation_type(sut):


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/bel-4020)

## Purpose 
<!-- what/why -->
Fix the web scaling alarms to use a better metric that will trigger autoscaling more quickly.
## Approach 
<!-- how -->
Update Web Autoscaling Alarms to use Target Response Time as the Metric.
We alarm and scale if the response time exceeds 5 seconds.
We scale one instance at a time if the response time is less than 10 and 3 instances if the response time is greater than 10s
We scale down one instance at a time, every 5 mins, once the response time drops below 5s.
## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Make sure tests pass.
Deployed locally to [repo-dash](https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#alarmsV2:alarm/repository-dashboard-prod-auto-scaling-out-alarm?~(search~'repository-dashboard))
## Screenshots/Video
<!-- show before/after of the change if possible -->
![image](https://github.com/user-attachments/assets/7ff2d5fa-0399-4942-acce-15436d34fd3f)
![image](https://github.com/user-attachments/assets/a48ed543-6efb-41cc-a820-29541f1b5965)
