### PR TITLE
Bel-4114 Set Deployment Maximum Percent to 120 for Worker Containers

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -69,6 +69,7 @@ class ContainerComponent(pulumi.ComponentResource):
         self.max_capacity = 100
         self.min_capacity = self.desired_count
         self.sns_topic_arn = kwargs.get('sns_topic_arn')
+        self.deployment_maximum_percent = kwargs.get('deployment_maximum_percent', 200)
 
         project = pulumi.get_project()
         self.project_stack = f"{project}-{stack}"
@@ -303,6 +304,7 @@ class ContainerComponent(pulumi.ComponentResource):
             propagate_tags="SERVICE",
             enable_execute_command=True,
             task_definition_args=self.task_definition_args,
+            deployment_maximum_percent=self.kwargs.get('deployment_maximum_percent', 200),
             tags=self.tags,
             opts=pulumi.ResourceOptions(parent=self),
         )

--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -304,7 +304,7 @@ class ContainerComponent(pulumi.ComponentResource):
             propagate_tags="SERVICE",
             enable_execute_command=True,
             task_definition_args=self.task_definition_args,
-            deployment_maximum_percent=self.kwargs.get('deployment_maximum_percent', 200),
+            deployment_maximum_percent=self.deployment_maximum_percent,
             tags=self.tags,
             opts=pulumi.ResourceOptions(parent=self),
         )

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -281,6 +281,7 @@ class RailsComponent(pulumi.ComponentResource):
         self.kwargs['desired_count'] = self.desired_worker_count
         self.kwargs['autoscale'] = False
         self.kwargs['worker_autoscale'] = self.worker_autoscale
+        self.kwargs['deployment_maximum_percent'] = 120
 
         self.worker_container = ContainerComponent("worker",
                                                    pulumi.ResourceOptions(parent=self,

--- a/deployment/src/tests/mocks.py
+++ b/deployment/src/tests/mocks.py
@@ -33,6 +33,7 @@ def get_pulumi_mocks(faker, fake_password=None, secret_string="{}"):
                     "propagate_tags": args.inputs.get("propagateTags"),
                     "enable_execute_command": args.inputs.get("enableExecuteCommand"),
                     "health_check_grace_period_seconds": args.inputs.get("healthCheckGracePeriodSeconds"),
+                    "deployment_maximum_percent": args.inputs.get("deploymentMaximumPercent"),
                 }
             if args.typ == "aws:rds/cluster:Cluster":
                 outputs = {

--- a/deployment/src/tests/test_container.py
+++ b/deployment/src/tests/test_container.py
@@ -600,6 +600,10 @@ def describe_container():
             def it_sets_the_task_role(sut):
                 return assert_outputs_equal(sut.fargate_service.task_definition_args["taskRole"]["roleArn"], sut.task_role.arn)
 
+            @pulumi.runtime.test
+            def it_sets_the_deployment_maximum_percent_to_200(sut):
+                return assert_output_equals(sut.fargate_service.deployment_maximum_percent, 200)
+
         def describe_with_custom_health_check_path():
             @pytest.fixture
             def custom_health_check_path(faker):

--- a/deployment/src/tests/test_rails_worker.py
+++ b/deployment/src/tests/test_rails_worker.py
@@ -84,3 +84,8 @@ def describe_a_pulumi_rails_app():
             def it_passes_worker_log_metric_filter_value_to_worker_container(sut, worker_log_metric_filters):
                 return assert_output_equals(sut.worker_container.log_metric_filters[0].metric_transformation.value,
                                             "$BLAH")
+
+        def describe_fargate_service_properties():
+            @pulumi.runtime.test
+            def it_sets_the_deployment_maximum_percent(sut):
+                return assert_output_equals(sut.worker_container.fargate_service.deployment_maximum_percent, 120)


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/bel-4114)

## Purpose 
<!-- what/why -->
Only allow 120% of containers for worker service during deployments
## Approach 
<!-- how -->
Added deployment_maximum_percent parameter to the fargate service in container.py
## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Added tests and tests pass
Deployed locally on repo-dash and verified config set in AWS
