### PR TITLE
Bel-4070-1 Change Running Task Alarm to use a threshold of 100

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -69,6 +69,7 @@ class ContainerComponent(pulumi.ComponentResource):
         self.max_capacity = 100
         self.min_capacity = self.desired_count
         self.sns_topic_arn = kwargs.get('sns_topic_arn')
+        self.binary_sns_topic_arn = 'arn:aws:sns:us-west-2:221871915463:DevOps-Opsgenie'
         self.deployment_maximum_percent = kwargs.get('deployment_maximum_percent', 200)
 
         project = pulumi.get_project()
@@ -438,10 +439,10 @@ class ContainerComponent(pulumi.ComponentResource):
             },
             period=60,
             statistic="Maximum",
-            threshold=25,
-            alarm_actions=[self.sns_topic_arn],
-            ok_actions=[self.sns_topic_arn],
-            alarm_description="Alarm when ECS service running tasks exceed 25",
+            threshold=100,
+            alarm_actions=[self.sns_topic_arn, self.binary_sns_topic_arn],
+            ok_actions=[self.sns_topic_arn, self.binary_sns_topic_arn],
+            alarm_description="Alarm when ECS service running tasks are at Max of 100",
             tags=self.tags
         )
 

--- a/deployment/src/tests/test_container_autoscaling.py
+++ b/deployment/src/tests/test_container_autoscaling.py
@@ -72,7 +72,7 @@ def describe_autoscaling():
 
             @pulumi.runtime.test
             def it_triggers_when_the_threshold_is_more_than_the_desired_count(sut):
-                expected_threshold = 25
+                expected_threshold = 100
                 actual_threshold = sut.running_tasks_alarm.threshold
                 assert_output_equals(actual_threshold, expected_threshold)
 


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/Bel-4070)

## Purpose 
<!-- what/why -->
Adjust alarm to use 100 as the threshold
## Approach 
<!-- how -->
Change the threshold to 100
## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Tests pass
Deployed locally on repo-dashboard
## Screenshots/Video
<!-- show before/after of the change if possible -->
![image](https://github.com/user-attachments/assets/8fbafb87-2b40-40c3-92b8-1478c76f34e8)

