### PR TITLE
BEL-3135 multiple partners for canvas ECS

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -444,7 +444,7 @@ class ContainerComponent(pulumi.ComponentResource):
             tags=self.tags
         )
 
-    def setup_load_balancer(self, kwargs, project, project_stack, stack):
+    def setup_load_balancer(self, kwargs, project, namespace, stack):
         self.certificate(project, stack)
 
         default_vpc = awsx.ec2.DefaultVpc("default_vpc")
@@ -452,7 +452,7 @@ class ContainerComponent(pulumi.ComponentResource):
 
         self.target_group = aws.lb.TargetGroup(
             "target_group",
-            name=f"{project_stack}-tg",
+            name=f"{namespace}-tg",
             port=self.container_port,
             protocol="HTTP",
             target_type="ip",
@@ -516,7 +516,7 @@ class ContainerComponent(pulumi.ComponentResource):
                                                            load_balancer_name, target_group_name).apply(lambda args:
                                                                                                         aws.cloudwatch.MetricAlarm(
                                                                                                             "healthy_host_metric_alarm",
-                                                                                                            name=f"{project_stack}-healthy-host-metric-alarm",
+                                                                                                            name=f"{namespace}-healthy-host-metric-alarm",
                                                                                                             actions_enabled=True,
                                                                                                             ok_actions=[
                                                                                                                 self.sns_topic_arn],
@@ -588,7 +588,7 @@ class ContainerComponent(pulumi.ComponentResource):
                                                              load_balancer_name, target_group_name).apply(lambda args:
                                                                                                           aws.cloudwatch.MetricAlarm(
                                                                                                               "unhealthy_host_metric_alarm",
-                                                                                                              name=f"{project_stack}-unhealthy-host-metric-alarm",
+                                                                                                              name=f"{namespace}-unhealthy-host-metric-alarm",
                                                                                                               actions_enabled=True,
                                                                                                               ok_actions=[
                                                                                                                   self.sns_topic_arn],

--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -476,6 +476,7 @@ class ContainerComponent(pulumi.ComponentResource):
             placement=alb.AlbPlacement.EXTERNAL,
             certificate_arn=self.cert.arn,
             tags=self.tags,
+            namespace=namespace,
         )
         self.alb = alb.Alb("loadbalancer", alb_args)
         self.load_balancer = self.alb.alb

--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -476,7 +476,7 @@ class ContainerComponent(pulumi.ComponentResource):
             placement=alb.AlbPlacement.EXTERNAL,
             certificate_arn=self.cert.arn,
             tags=self.tags,
-            namespace=namespace,
+            namespace=self.kwargs.get('namespace', None)
         )
         self.alb = alb.Alb("loadbalancer", alb_args)
         self.load_balancer = self.alb.alb

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -140,10 +140,14 @@ class RailsComponent(pulumi.ComponentResource):
             if 'queue_redis' not in self.kwargs:
                 self.kwargs['queue_redis'] = True
         if 'queue_redis' in self.kwargs:
+            queue_redis_kwargs = {}
+            if 'namespace' in self.kwargs:
+                queue_redis_kwargs['namespace'] = self.kwargs['namespace']
+
             if isinstance(self.kwargs['queue_redis'], RedisComponent):
                 self.queue_redis = self.kwargs['queue_redis']
             elif self.kwargs['queue_redis']:
-                self.queue_redis = QueueComponent("queue-redis")
+                self.queue_redis = QueueComponent("queue-redis", **queue_redis_kwargs)
 
             if self.queue_redis:
                 self.env_vars['QUEUE_REDIS_URL'] = self.queue_redis.url
@@ -151,7 +155,11 @@ class RailsComponent(pulumi.ComponentResource):
             if isinstance(self.kwargs['cache_redis'], RedisComponent):
                 self.cache_redis = self.kwargs['cache_redis']
             elif self.kwargs['cache_redis']:
-                self.cache_redis = CacheComponent("cache-redis")
+                cache_redis_kwargs = {}
+                if 'namespace' in self.kwargs:
+                    cache_redis_kwargs['namespace'] = self.kwargs['namespace']
+
+                self.cache_redis = CacheComponent("cache-redis", **cache_redis_kwargs)
 
             if self.cache_redis:
                 self.env_vars['CACHE_REDIS_URL'] = self.cache_redis.url

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -387,7 +387,7 @@ class RailsComponent(pulumi.ComponentResource):
     def setup_dashboard(self, namespace):
         self.dashboard = DashboardComponent(
             name="dashboard",
-            project_stack=namespace,
+            namespace=self.namespace,
             web_container=self.web_container,
             ecs_cluster=self.ecs_cluster,
             rds_serverless_cluster_instance=self.rds_serverless_cluster_instance,

--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -238,7 +238,7 @@ class RailsComponent(pulumi.ComponentResource):
             self.migration_container.fargate_service.service.network_configuration.security_groups)  # pragma: no cover
         execution_inputs = ExecutionResourceInputs(
             cluster=self.ecs_cluster.arn,
-            family=self.migration_container.project_stack,
+            family=self.migration_container.namespace,
             subnets=subnets,
             security_groups=self.container_security_groups,
         )

--- a/deployment/src/strongmind_deployment/redis.py
+++ b/deployment/src/strongmind_deployment/redis.py
@@ -19,7 +19,7 @@ class RedisComponent(pulumi.ComponentResource):
 
         project = pulumi.get_project()
         stack = pulumi.get_stack()
-        project_stack = f"{project}-{stack}"
+        self.namespace = self.kwargs.get('namespace', f"{project}-{stack}")
 
         path = subprocess.check_output(['git', 'rev-parse', '--show-toplevel']).decode('utf-8').strip()
         file_path = f"{path}/CODEOWNERS"
@@ -39,7 +39,7 @@ class RedisComponent(pulumi.ComponentResource):
 
         self.cluster = aws.elasticache.Cluster(
             name,
-            cluster_id=f'{project_stack}-{name}',
+            cluster_id=f'{self.namespace}-{name}',
             engine="redis",
             node_type=self.node_type,
             engine_version="7.0",
@@ -61,8 +61,8 @@ class QueueComponent(RedisComponent):
     def __init__(self, name, opts=None, **kwargs):
         project = pulumi.get_project()
         stack = pulumi.get_stack()
-        project_stack = f"{project}-{stack}"
-        kwargs['parameter_group_name'] = f"{project_stack}-queue-redis7"
+        namespace = kwargs.get('namespace', f"{project}-{stack}")
+        kwargs['parameter_group_name'] = f"{namespace}-queue-redis7"
         self.parameter_group = aws.elasticache.ParameterGroup(
             f"{name}-parameter-group",
             name=kwargs['parameter_group_name'],
@@ -80,8 +80,8 @@ class CacheComponent(RedisComponent):
     def __init__(self, name, opts=None, **kwargs):
         project = pulumi.get_project()
         stack = pulumi.get_stack()
-        project_stack = f"{project}-{stack}"
-        kwargs['parameter_group_name'] = f"{project_stack}-cache-redis7"
+        namespace = kwargs.get('namespace', f"{project}-{stack}")
+        kwargs['parameter_group_name'] = f"{namespace}-cache-redis7"
         self.parameter_group = aws.elasticache.ParameterGroup(
             f"{name}-parameter-group",
             name=kwargs['parameter_group_name'],

--- a/deployment/src/strongmind_deployment/secrets.py
+++ b/deployment/src/strongmind_deployment/secrets.py
@@ -22,7 +22,7 @@ class SecretsComponent(pulumi.ComponentResource):
 
         project = pulumi.get_project()
         stack = pulumi.get_stack()
-        project_stack = f"{project}-{stack}"
+        self.namespace = kwargs.get('namespace', f"{project}-{stack}")
 
         path = subprocess.check_output(['git', 'rev-parse', '--show-toplevel']).decode('utf-8').strip()
         file_path = f"{path}/CODEOWNERS"
@@ -38,14 +38,14 @@ class SecretsComponent(pulumi.ComponentResource):
         }
 
         self.sm_secret = aws.secretsmanager.Secret(
-            f"{project_stack}-secrets",
-            name=f"{project_stack}-secrets",
+            f"{self.namespace}-secrets",
+            name=f"{self.namespace}-secrets",
             tags=self.tags
         )
 
         # put initial dummy secret value
         self.sm_secret_version = aws.secretsmanager.SecretVersion(
-            f"{project_stack}-secrets-version",
+            f"{self.namespace}-secrets-version",
             secret_id=self.sm_secret.arn,
             secret_string=self.secret_string
         )

--- a/deployment/src/strongmind_deployment/util.py
+++ b/deployment/src/strongmind_deployment/util.py
@@ -27,9 +27,9 @@ def get_account_stack_name(force_stack: str = None) -> str:
     return f"organization/account/{account_stack}"
 
 
-def create_ecs_cluster(parent_component, project_stack):
+def create_ecs_cluster(parent_component, name):
     return aws.ecs.Cluster("cluster",
-                           name=project_stack,
+                           name=name,
                            tags=parent_component.tags,
                            settings=[{
                                "name": "containerInsights",

--- a/deployment/src/strongmind_deployment/worker_autoscale.py
+++ b/deployment/src/strongmind_deployment/worker_autoscale.py
@@ -16,7 +16,7 @@ class WorkerAutoscaleComponent(pulumi.ComponentResource):
         self.worker_autoscaling_out_alarm = None
         self.worker_autoscaling_out_policy = None
         self.worker_autoscaling_target = None
-        self.project_stack = pulumi.get_project() + "-" + pulumi.get_stack()
+        self.namespace = kwargs.get("namespace", f"{pulumi.get_project()}-{pulumi.get_stack()}")
         self.worker_max_capacity = kwargs.get('worker_max_number_of_instances', 100)
         self.worker_min_capacity = kwargs.get('worker_min_number_of_instances', 1)
         self.scaling_threshold = kwargs.get('max_queue_latency_threshold', 60)
@@ -29,13 +29,13 @@ class WorkerAutoscaleComponent(pulumi.ComponentResource):
             "worker_autoscaling_target",
             max_capacity=self.worker_max_capacity,
             min_capacity=self.worker_min_capacity,
-            resource_id=f"service/{self.project_stack}/{self.project_stack}-worker",
+            resource_id=f"service/{self.namespace}/{self.namespace}-worker",
             scalable_dimension="ecs:service:DesiredCount",
             service_namespace="ecs",
         )
         self.worker_autoscaling_out_policy = aws.appautoscaling.Policy(
             "worker_autoscaling_out_policy",
-            name=f"{self.project_stack}-worker-autoscaling-out-policy",
+            name=f"{self.namespace}-worker-autoscaling-out-policy",
             policy_type="StepScaling",
             resource_id=self.worker_autoscaling_target.resource_id,
             scalable_dimension=self.worker_autoscaling_target.scalable_dimension,
@@ -60,7 +60,7 @@ class WorkerAutoscaleComponent(pulumi.ComponentResource):
 
         self.worker_autoscaling_out_alarm = aws.cloudwatch.MetricAlarm(
             "worker_autoscaling_out_alarm",
-            name=f"{self.project_stack}-worker-auto-scaling-out-alarm",
+            name=f"{self.namespace}-worker-auto-scaling-out-alarm",
             comparison_operator="GreaterThanThreshold",
             evaluation_periods=1,
             metric_name="MaxQueueLatency",
@@ -68,7 +68,7 @@ class WorkerAutoscaleComponent(pulumi.ComponentResource):
             dimensions={
                 "QueueName": "AllQueues"
             },
-            namespace=self.project_stack,
+            namespace=self.namespace,
             period=60,
             statistic="Maximum",
             threshold=self.scaling_threshold,
@@ -77,7 +77,7 @@ class WorkerAutoscaleComponent(pulumi.ComponentResource):
 
         self.worker_queue_latency_alarm = aws.cloudwatch.MetricAlarm(
             "worker_queue_latency_alarm",
-            name=f"{self.project_stack}-worker-queue-latency-alarm",
+            name=f"{self.namespace}-worker-queue-latency-alarm",
             comparison_operator="GreaterThanThreshold",
             evaluation_periods=1,
             metric_name="MaxQueueLatency",
@@ -85,7 +85,7 @@ class WorkerAutoscaleComponent(pulumi.ComponentResource):
             dimensions={
                 "QueueName": "AllQueues"
             },
-            namespace=self.project_stack,
+            namespace=self.namespace,
             period=60,
             statistic="Maximum",
             threshold=self.alert_threshold,
@@ -95,7 +95,7 @@ class WorkerAutoscaleComponent(pulumi.ComponentResource):
 
         self.worker_autoscaling_in_policy = aws.appautoscaling.Policy(
             "worker_autoscaling_in_policy",
-            name=f"{self.project_stack}-worker-autoscaling-in-policy",
+            name=f"{self.namespace}-worker-autoscaling-in-policy",
             policy_type="StepScaling",
             resource_id=self.worker_autoscaling_target.resource_id,
             scalable_dimension=self.worker_autoscaling_target.scalable_dimension,
@@ -115,7 +115,7 @@ class WorkerAutoscaleComponent(pulumi.ComponentResource):
 
         self.worker_autoscaling_in_alarm = aws.cloudwatch.MetricAlarm(
             "worker_autoscaling_in_alarm",
-            name=f"{self.project_stack}-worker-auto-scaling-in-alarm",
+            name=f"{self.namespace}-worker-auto-scaling-in-alarm",
             comparison_operator="LessThanOrEqualToThreshold",
             evaluation_periods=5,
             metric_name="MaxQueueLatency",
@@ -123,7 +123,7 @@ class WorkerAutoscaleComponent(pulumi.ComponentResource):
             dimensions={
                 "QueueName": "AllQueues"
             },
-            namespace=self.project_stack,
+            namespace=self.namespace,
             period=60,
             statistic="Maximum",
             threshold=self.scaling_threshold,

--- a/deployment/src/tests/conftest.py
+++ b/deployment/src/tests/conftest.py
@@ -1,12 +1,16 @@
 import asyncio
 import os
 from concurrent.futures import ThreadPoolExecutor
+from random import randint
 
 import pulumi
 import pytest
 
 from tests.mocks import ImmediateExecutor
 
+@pytest.fixture(scope="session", autouse=True)
+def faker_seed():
+    return randint(0, 100000)
 
 @pytest.fixture
 def pulumi_set_mocks(pulumi_mocks, app_name, stack):

--- a/deployment/src/tests/test_alb.py
+++ b/deployment/src/tests/test_alb.py
@@ -31,7 +31,7 @@ def describe_a_application_load_balancer_component():
 
     @pytest.fixture
     def alb_args(vpc_id, certificate_arn):
-        from alb import AlbArgs
+        from strongmind_deployment.alb import AlbArgs
         return AlbArgs(
             vpc_id=vpc_id,
             subnets=['subnet-123456', 'subnet-654321'],

--- a/deployment/src/tests/test_alb.py
+++ b/deployment/src/tests/test_alb.py
@@ -4,7 +4,7 @@ import pulumi.runtime
 import pytest
 
 from strongmind_deployment.alb import AlbPlacement
-from mocks import get_pulumi_mocks
+from tests.mocks import get_pulumi_mocks
 
 
 def describe_a_application_load_balancer_component():

--- a/deployment/src/tests/test_alb.py
+++ b/deployment/src/tests/test_alb.py
@@ -50,7 +50,7 @@ def describe_a_application_load_balancer_component():
 
     @pytest.fixture
     def sut(name, alb_args, pulumi_set_mocks):
-        from strongmind.alb import Alb
+        from strongmind_deployment.alb import Alb
         return Alb(name, alb_args)
 
     @pulumi.runtime.test
@@ -73,7 +73,7 @@ def describe_a_application_load_balancer_component():
 
         @pytest.fixture
         def alb_args(vpc_id, certificate_arn, namespace):
-            from strongmind.alb import AlbArgs
+            from strongmind_deployment.alb import AlbArgs
             return AlbArgs(
                 vpc_id=vpc_id,
                 subnets=['subnet-123456', 'subnet-654321'],
@@ -85,7 +85,7 @@ def describe_a_application_load_balancer_component():
 
         @pytest.fixture
         def sut(name, alb_args, pulumi_set_mocks):
-            from strongmind.alb import Alb
+            from strongmind_deployment.alb import Alb
             return Alb(name, alb_args)
 
         def it_has_a_custom_namespace(sut, namespace):

--- a/deployment/src/tests/test_alb.py
+++ b/deployment/src/tests/test_alb.py
@@ -3,7 +3,7 @@ import os
 import pulumi.runtime
 import pytest
 
-from alb import AlbPlacement
+from strongmind_deployment.alb import AlbPlacement
 from mocks import get_pulumi_mocks
 
 

--- a/deployment/src/tests/test_alb.py
+++ b/deployment/src/tests/test_alb.py
@@ -50,7 +50,7 @@ def describe_a_application_load_balancer_component():
 
     @pytest.fixture
     def sut(name, alb_args, pulumi_set_mocks):
-        from alb import Alb
+        from strongmind.alb import Alb
         return Alb(name, alb_args)
 
     @pulumi.runtime.test
@@ -73,7 +73,7 @@ def describe_a_application_load_balancer_component():
 
         @pytest.fixture
         def alb_args(vpc_id, certificate_arn, namespace):
-            from alb import AlbArgs
+            from strongmind.alb import AlbArgs
             return AlbArgs(
                 vpc_id=vpc_id,
                 subnets=['subnet-123456', 'subnet-654321'],
@@ -85,7 +85,7 @@ def describe_a_application_load_balancer_component():
 
         @pytest.fixture
         def sut(name, alb_args, pulumi_set_mocks):
-            from alb import Alb
+            from strongmind.alb import Alb
             return Alb(name, alb_args)
 
         def it_has_a_custom_namespace(sut, namespace):

--- a/deployment/src/tests/test_alb.py
+++ b/deployment/src/tests/test_alb.py
@@ -1,0 +1,92 @@
+import os
+
+import pulumi.runtime
+import pytest
+
+from alb import AlbPlacement
+from mocks import get_pulumi_mocks
+
+
+def describe_a_application_load_balancer_component():
+    @pytest.fixture
+    def name(faker):
+        return faker.word()
+
+    @pytest.fixture
+    def app_name(faker):
+        return faker.word()
+
+    @pytest.fixture
+    def environment(faker):
+        os.environ["ENVIRONMENT_NAME"] = faker.word()
+        return os.environ["ENVIRONMENT_NAME"]
+
+    @pytest.fixture
+    def stack(environment):
+        return environment
+
+    @pytest.fixture
+    def pulumi_mocks(faker):
+        return get_pulumi_mocks(faker)
+
+    @pytest.fixture
+    def alb_args(vpc_id, certificate_arn):
+        from alb import AlbArgs
+        return AlbArgs(
+            vpc_id=vpc_id,
+            subnets=['subnet-123456', 'subnet-654321'],
+            certificate_arn=certificate_arn,
+            placement=AlbPlacement.EXTERNAL,
+            tags={},
+        )
+
+    @pytest.fixture
+    def vpc_id():
+        return "vpc-123456"
+
+    @pytest.fixture
+    def certificate_arn():
+        return "arn:aws:acm:us-west-2:123456789012:certificate/12345678-1234-1234-1234-123456789012"
+
+    @pytest.fixture
+    def sut(name, alb_args, pulumi_set_mocks):
+        from alb import Alb
+        return Alb(name, alb_args)
+
+    @pulumi.runtime.test
+    def it_exists(sut):
+        assert sut
+
+    def it_has_a_name(sut, name):
+        assert sut._name == name
+
+    def it_has_a_type(sut):
+        assert sut._type == "strongmind:global_build:commons:alb"
+
+    def it_has_a_namespace_that_defaults_to_project_stack(sut, app_name, stack):
+        assert sut.namespace == f"{app_name}-{stack}"
+
+    def describe_with_a_custom_namespace():
+        @pytest.fixture
+        def namespace(faker):
+            return faker.word()
+
+        @pytest.fixture
+        def alb_args(vpc_id, certificate_arn, namespace):
+            from alb import AlbArgs
+            return AlbArgs(
+                vpc_id=vpc_id,
+                subnets=['subnet-123456', 'subnet-654321'],
+                certificate_arn=certificate_arn,
+                placement=AlbPlacement.EXTERNAL,
+                tags={},
+                namespace=namespace,
+            )
+
+        @pytest.fixture
+        def sut(name, alb_args, pulumi_set_mocks):
+            from alb import Alb
+            return Alb(name, alb_args)
+
+        def it_has_a_custom_namespace(sut, namespace):
+            assert sut.namespace == namespace

--- a/deployment/src/tests/test_container.py
+++ b/deployment/src/tests/test_container.py
@@ -928,6 +928,9 @@ def describe_container():
         def it_has_a_namespace(sut, namespace):
             assert sut.namespace == namespace
 
+        @pulumi.runtime.test
+        def it_sets_the_alb_namespace(sut, namespace):
+            assert sut.alb.namespace == namespace
 
         def describe_with_a_non_container_default_name():
             @pytest.fixture
@@ -941,5 +944,6 @@ def describe_container():
                                                                           **component_kwargs
                                                                           )
 
+            @pulumi.runtime.test
             def it_adds_the_component_name_to_the_namespace(sut, namespace, component_name):
                 assert sut.namespace == f"{namespace}-{component_name}"

--- a/deployment/src/tests/test_container_autoscaling.py
+++ b/deployment/src/tests/test_container_autoscaling.py
@@ -42,7 +42,7 @@ def describe_autoscaling():
 
         @pulumi.runtime.test
         def it_uses_the_clusters_resource_id(sut):
-            resource_id = f"service/{sut.project_stack}/{sut.project_stack}"
+            resource_id = f"service/{sut.namespace}/{sut.namespace}"
             return assert_output_equals(sut.autoscaling_target.resource_id, resource_id)
 
         def describe_running_tasks_alarm():
@@ -240,7 +240,7 @@ def describe_autoscaling():
 
             @pulumi.runtime.test
             def it_uses_the_clusters_resource_id(sut):
-                resource_id = f"service/{sut.project_stack}/{sut.project_stack}"
+                resource_id = f"service/{sut.namespace}/{sut.namespace}"
                 return assert_output_equals(sut.autoscaling_in_policy.resource_id, resource_id)
 
             @pulumi.runtime.test
@@ -306,7 +306,7 @@ def describe_autoscaling():
 
             @pulumi.runtime.test
             def it_uses_the_clusters_resource_id(sut):
-                resource_id = f"service/{sut.project_stack}/{sut.project_stack}"
+                resource_id = f"service/{sut.namespace}/{sut.namespace}"
                 return assert_output_equals(sut.autoscaling_out_policy.resource_id, resource_id)
 
             @pulumi.runtime.test

--- a/deployment/src/tests/test_dashboard.py
+++ b/deployment/src/tests/test_dashboard.py
@@ -109,7 +109,7 @@ def describe_a_dashboard_component():
 
         @pytest.fixture
         def sut(name, web_container, ecs_cluster, rds_serverless_cluster_instance, namespace, pulumi_set_mocks):
-            from dashboard import DashboardComponent
+            from strongmind_deployment.dashboard import DashboardComponent
             return DashboardComponent(name,
                                       project_stack='project-stack',
                                       web_container=web_container,

--- a/deployment/src/tests/test_dashboard.py
+++ b/deployment/src/tests/test_dashboard.py
@@ -5,7 +5,7 @@ import pytest
 import pulumi_aws as aws
 
 from strongmind_deployment.container import ContainerComponent
-from mocks import get_pulumi_mocks
+from tests.mocks import get_pulumi_mocks
 
 
 def describe_a_dashboard_component():

--- a/deployment/src/tests/test_dashboard.py
+++ b/deployment/src/tests/test_dashboard.py
@@ -1,0 +1,123 @@
+import os
+
+import pulumi.runtime
+import pytest
+import pulumi_aws as aws
+
+from container import ContainerComponent
+from mocks import get_pulumi_mocks
+from util import create_ecs_cluster
+
+
+def describe_a_dashboard_component():
+    @pytest.fixture
+    def name(faker):
+        return faker.word()
+
+    @pytest.fixture
+    def app_name(faker):
+        return faker.word()
+
+    @pytest.fixture
+    def environment(faker):
+        os.environ["ENVIRONMENT_NAME"] = faker.word()
+        return os.environ["ENVIRONMENT_NAME"]
+
+    @pytest.fixture
+    def stack(environment):
+        return environment
+
+    @pytest.fixture
+    def pulumi_mocks(faker):
+        return get_pulumi_mocks(faker)
+
+    @pytest.fixture
+    def domain_validation_options(faker):
+        class FakeValidationOption:
+            def __init__(self):
+                self.resource_record_name = faker.word()
+                self.resource_record_value = faker.word()
+                self.resource_record_type = faker.word()
+
+        return [FakeValidationOption()]
+
+    @pytest.fixture
+    def web_container_component_kwargs(pulumi_set_mocks, domain_validation_options):
+        return {
+            "app_path": "/",
+            "container_port": '80',
+            "cpu": "1",
+            "memory": "128",
+            "entry_point": "/entry_point",
+            "command": "command",
+            "container_image": "image",
+            "env_vars": {},
+            "secrets": {},
+            "zone_id": "something",
+            "load_balancer_dns_name": "something.strongmind.com",
+            "domain_validation_options": domain_validation_options
+        }
+
+    @pytest.fixture
+    def web_container(name, web_container_component_kwargs):
+        return ContainerComponent(name, **web_container_component_kwargs)
+
+    @pytest.fixture
+    def ecs_cluster(pulumi_set_mocks):
+        return aws.ecs.Cluster("cluster",
+                           tags={},
+                           settings=[{
+                               "name": "containerInsights",
+                               "value": "enabled",
+                           }],
+                           opts=pulumi.ResourceOptions(),
+                           )
+
+    @pytest.fixture
+    def rds_serverless_cluster_instance(pulumi_set_mocks):
+        return aws.rds.ClusterInstance("rds-cluster-instance",
+                                       cluster_identifier="rds-cluster",
+                                       instance_class="db.t3.micro",
+                                       engine="aurora-postgresql",
+                                       publicly_accessible=True,
+                                       opts=pulumi.ResourceOptions(),
+                                       )
+    @pytest.fixture
+    def sut(name, web_container, ecs_cluster, rds_serverless_cluster_instance, pulumi_set_mocks):
+        from dashboard import DashboardComponent
+        return DashboardComponent(name,
+                                  project_stack='project-stack',
+                                  web_container=web_container,
+                                  ecs_cluster=ecs_cluster,
+                                  rds_serverless_cluster_instance=rds_serverless_cluster_instance)
+
+    @pulumi.runtime.test
+    def it_exists(sut):
+        assert True
+
+    @pulumi.runtime.test
+    def it_has_a_default_namespace_based_on_project_stack(sut, app_name, stack):
+        assert sut.namespace == f"{app_name}-{stack}"
+
+    @pulumi.runtime.test
+    def it_no_longer_has_a_project_stack(sut):
+        assert not hasattr(sut, 'project_stack')
+
+    def describe_with_a_custom_namespace():
+        @pytest.fixture
+        def namespace(faker):
+            return faker.word()
+
+        @pytest.fixture
+        def sut(name, web_container, ecs_cluster, rds_serverless_cluster_instance, namespace, pulumi_set_mocks):
+            from dashboard import DashboardComponent
+            return DashboardComponent(name,
+                                      project_stack='project-stack',
+                                      web_container=web_container,
+                                      ecs_cluster=ecs_cluster,
+                                      rds_serverless_cluster_instance=rds_serverless_cluster_instance,
+                                      namespace=namespace)
+
+        @pulumi.runtime.test
+        def it_has_a_custom_namespace(sut, namespace):
+            assert sut.namespace == namespace

--- a/deployment/src/tests/test_dashboard.py
+++ b/deployment/src/tests/test_dashboard.py
@@ -83,7 +83,7 @@ def describe_a_dashboard_component():
                                        )
     @pytest.fixture
     def sut(name, web_container, ecs_cluster, rds_serverless_cluster_instance, pulumi_set_mocks):
-        from dashboard import DashboardComponent
+        from strongmind_deployment.dashboard import DashboardComponent
         return DashboardComponent(name,
                                   project_stack='project-stack',
                                   web_container=web_container,

--- a/deployment/src/tests/test_dashboard.py
+++ b/deployment/src/tests/test_dashboard.py
@@ -4,9 +4,8 @@ import pulumi.runtime
 import pytest
 import pulumi_aws as aws
 
-from container import ContainerComponent
+from strongmind_deployment.container import ContainerComponent
 from mocks import get_pulumi_mocks
-from util import create_ecs_cluster
 
 
 def describe_a_dashboard_component():

--- a/deployment/src/tests/test_rails.py
+++ b/deployment/src/tests/test_rails.py
@@ -953,3 +953,17 @@ def describe_a_pulumi_rails_component():
         @pulumi.runtime.test
         def it_does_not_create_worker_autoscale(sut):
             assert sut.worker_container.worker_autoscaling is None
+
+    def describe_with_a_custom_namespace():
+        @pytest.fixture
+        def namespace(faker):
+            return f'{faker.word()}-{faker.word()}-namespace'
+
+        @pytest.fixture
+        def component_kwargs(component_kwargs, namespace):
+            component_kwargs['namespace'] = namespace
+            return component_kwargs
+
+        @pulumi.runtime.test
+        def it_creates_secrets_with_the_namespace(sut, namespace):
+            assert sut.secret.namespace == namespace

--- a/deployment/src/tests/test_rails.py
+++ b/deployment/src/tests/test_rails.py
@@ -346,6 +346,30 @@ def describe_a_pulumi_rails_component():
         def it_sets_the_name_to_the_app_name(sut, stack, app_name):
             return assert_output_equals(sut.rds_serverless_cluster.cluster_identifier, f'{app_name}-{stack}')
 
+        def describe_with_a_custom_namespace():
+            @pytest.fixture
+            def namespace(faker):
+                return f'{faker.word()}-{faker.word()}'
+
+            @pytest.fixture
+            def component_kwargs(component_kwargs, namespace):
+                component_kwargs['namespace'] = namespace
+                return component_kwargs
+
+            @pulumi.runtime.test
+            def it_creates_a_cluster_with_an_overridden_name(sut, namespace):
+                return assert_output_equals(sut.rds_serverless_cluster.cluster_identifier, namespace)
+
+            @pulumi.runtime.test
+            def it_sets_final_snapshot_identifier(sut, namespace):
+                return assert_output_equals(sut.rds_serverless_cluster.final_snapshot_identifier,
+                                            f"{namespace}-final-snapshot")
+
+            @pulumi.runtime.test
+            def it_sets_the_master_username(sut, namespace):
+                return assert_output_equals(sut.rds_serverless_cluster.master_username,
+                                            f'{namespace}'.replace('-', '_'))
+
         @pulumi.runtime.test
         def it_sets_the_master_username(sut, stack, app_name):
             return assert_output_equals(sut.rds_serverless_cluster.master_username,
@@ -594,9 +618,42 @@ def describe_a_pulumi_rails_component():
                 sut.rds_serverless_cluster_instance.identifier,
             ).apply(check_rds_cluster_instance_identifier)
 
+        def describe_with_a_custom_namespace():
+            @pytest.fixture
+            def namespace(faker):
+                return f'{faker.word()}-{faker.word()}'
+
+            @pytest.fixture
+            def component_kwargs(component_kwargs, namespace):
+                component_kwargs['namespace'] = namespace
+                return component_kwargs
+
+            @pulumi.runtime.test
+            def it_creates_a_cluster_instance_with_an_overridden_namespace(sut, namespace):
+                return assert_output_equals(sut.rds_serverless_cluster_instance.identifier, namespace)
+
         @pulumi.runtime.test
         def it_is_publicly_accessible(sut, app_name):
             return assert_output_equals(sut.rds_serverless_cluster_instance.publicly_accessible, True)
+
+    def describe_an_ecs_cluster():
+        @pulumi.runtime.test
+        def it_creates_a_cluster(sut, app_name, stack):
+            return assert_output_equals(sut.ecs_cluster.name, f"{app_name}-{stack}")
+
+        def describe_with_a_custom_namespace():
+            @pytest.fixture
+            def namespace(faker):
+                return f'{faker.word()}-{faker.word()}'
+
+            @pytest.fixture
+            def component_kwargs(component_kwargs, namespace):
+                component_kwargs['namespace'] = namespace
+                return component_kwargs
+
+            @pulumi.runtime.test
+            def it_creates_a_cluster_with_an_overridden_namespace(sut, namespace):
+                return assert_output_equals(sut.ecs_cluster.name, namespace)
 
     def describe_a_ecs_task():
         @pulumi.runtime.test

--- a/deployment/src/tests/test_rails.py
+++ b/deployment/src/tests/test_rails.py
@@ -794,6 +794,20 @@ def describe_a_pulumi_rails_component():
         def test_it_names_the_queue_redis(sut, app_name, stack):
             return assert_output_equals(sut.queue_redis.cluster.cluster_id, f"{app_name}-{stack}-queue-redis")
 
+        def describe_with_a_custom_namespace():
+            @pytest.fixture
+            def namespace(faker):
+                return f'{faker.word()}-{faker.word()}-namespace'
+
+            @pytest.fixture
+            def component_kwargs(component_kwargs, namespace):
+                component_kwargs['namespace'] = namespace
+                return component_kwargs
+
+            @pulumi.runtime.test
+            def it_creates_a_queue_redis_with_custom_namespace(sut, namespace):
+                return assert_output_equals(sut.queue_redis.cluster.cluster_id, f'{namespace}-queue-redis')
+
         @pulumi.runtime.test
         def it_sends_the_url_to_the_ecs_environment(sut):
             return assert_outputs_equal(sut.env_vars["QUEUE_REDIS_URL"], sut.queue_redis.url)
@@ -827,6 +841,20 @@ def describe_a_pulumi_rails_component():
         @pulumi.runtime.test
         def it_names_the_cache_redis(sut, app_name, stack):
             return assert_output_equals(sut.cache_redis.cluster.cluster_id, f"{app_name}-{stack}-cache-redis")
+
+        def describe_with_a_custom_namespace():
+            @pytest.fixture
+            def namespace(faker):
+                return f'{faker.word()}-{faker.word()}-namespace'
+
+            @pytest.fixture
+            def component_kwargs(component_kwargs, namespace):
+                component_kwargs['namespace'] = namespace
+                return component_kwargs
+
+            @pulumi.runtime.test
+            def it_creates_a_cache_redis_with_custom_namespace(sut, namespace):
+                return assert_output_equals(sut.cache_redis.cluster.cluster_id, f'{namespace}-cache-redis')
 
         @pulumi.runtime.test
         def it_sends_the_url_to_the_ecs_environment(sut):

--- a/deployment/src/tests/test_secrets.py
+++ b/deployment/src/tests/test_secrets.py
@@ -32,6 +32,10 @@ def describe_a_pulumi_secretsmanager_component():
         return faker.word()
 
     @pytest.fixture
+    def namespace(faker):
+        return f"{faker.word()}-namespace"
+
+    @pytest.fixture
     def component_arguments():
         return {}
 
@@ -74,6 +78,16 @@ def describe_a_pulumi_secretsmanager_component():
         @pulumi.runtime.test
         def it_has_a_sm_secret_name(sut, name, app_name, stack):
             return assert_output_equals(sut.sm_secret.name, f"{app_name}-{stack}-secrets")
+
+        def describe_with_a_custom_namespace():
+            @pytest.fixture
+            def component_arguments(component_arguments, namespace):
+                component_arguments["namespace"] = namespace
+                return component_arguments
+
+            @pulumi.runtime.test
+            def it_uses_the_namespace_in_the_secret_name(sut, namespace):
+                return assert_output_equals(sut.sm_secret.name, f"{namespace}-secrets")
 
         @pulumi.runtime.test
         def it_has_a_sm_secret_version_secret_string(sut):

--- a/deployment/src/tests/test_worker_container_autoscaling.py
+++ b/deployment/src/tests/test_worker_container_autoscaling.py
@@ -20,8 +20,16 @@ def describe_worker_autoscaling():
             assert sut.worker_autoscaling
 
         @pulumi.runtime.test
+        def it_has_a_default_namespace(sut, app_name, stack):
+            assert sut.worker_autoscaling.namespace == f"{app_name}-{stack}"
+
+        @pulumi.runtime.test
         def it_has_an_autoscaling_target(sut):
             assert sut.worker_autoscaling.worker_autoscaling_target
+
+        @pulumi.runtime.test
+        def it_no_longer_has_a_project_stack(sut):
+            assert not hasattr(sut.worker_autoscaling, "project_stack")
 
         @pytest.fixture
         def autoscaling_target(sut):
@@ -364,6 +372,21 @@ def describe_worker_autoscaling():
                 @pulumi.runtime.test
                 def It_step_scales_by_one_instance(step):
                     return assert_output_equals(step.scaling_adjustment, 1)
+
+
+        def describe_when_given_a_custom_namespace():
+            @pytest.fixture
+            def namespace(faker):
+                return faker.word() + "_namespace"
+
+            @pytest.fixture
+            def component_kwargs(component_kwargs, namespace):
+                component_kwargs["namespace"] = namespace
+                return component_kwargs
+
+            @pulumi.runtime.test
+            def it_uses_the_custom_namespace(sut, namespace):
+                assert sut.worker_autoscaling.namespace == namespace
 
     def describe_when_turned_off():
         @pytest.fixture

--- a/deployment/src/tests/test_worker_container_autoscaling.py
+++ b/deployment/src/tests/test_worker_container_autoscaling.py
@@ -55,7 +55,7 @@ def describe_worker_autoscaling():
 
         @pulumi.runtime.test
         def it_uses_the_clusters_resource_id(sut, autoscaling_target):
-            resource_id = f"service/{sut.project_stack}/{sut.project_stack}-worker"
+            resource_id = f"service/{sut.namespace}/{sut.namespace}-worker"
             return assert_output_equals(autoscaling_target.resource_id, resource_id)
 
         def describe_autoscaling_out_alarm():
@@ -94,7 +94,7 @@ def describe_worker_autoscaling():
 
             @pulumi.runtime.test
             def it_belongs_to_the_project_stack_namespace(sut, autoscaling_out_alarm):
-                return assert_output_equals(autoscaling_out_alarm.namespace, sut.project_stack)
+                return assert_output_equals(autoscaling_out_alarm.namespace, sut.namespace)
 
             @pulumi.runtime.test
             def it_runs_every_minute(autoscaling_out_alarm):
@@ -144,7 +144,7 @@ def describe_worker_autoscaling():
 
             @pulumi.runtime.test
             def it_belongs_to_the_project_stack_namespace(sut, queue_latency_alarm):
-                return assert_output_equals(queue_latency_alarm.namespace, sut.project_stack)
+                return assert_output_equals(queue_latency_alarm.namespace, sut.namespace)
 
             @pulumi.runtime.test
             def it_runs_every_minute(queue_latency_alarm):
@@ -197,7 +197,7 @@ def describe_worker_autoscaling():
 
             @pulumi.runtime.test
             def it_belongs_to_the_project_stack_namespace(sut, autoscaling_in_alarm):
-                return assert_output_equals(autoscaling_in_alarm.namespace, sut.project_stack)
+                return assert_output_equals(autoscaling_in_alarm.namespace, sut.namespace)
 
             @pulumi.runtime.test
             def it_runs_every_minute(autoscaling_in_alarm):
@@ -227,7 +227,7 @@ def describe_worker_autoscaling():
 
             @pulumi.runtime.test
             def it_uses_the_clusters_resource_id(sut, autoscaling_in_policy):
-                resource_id = f"service/{sut.project_stack}/{sut.project_stack}-worker"
+                resource_id = f"service/{sut.namespace}/{sut.namespace}-worker"
                 return assert_output_equals(autoscaling_in_policy.resource_id, resource_id)
 
             @pulumi.runtime.test
@@ -296,7 +296,7 @@ def describe_worker_autoscaling():
 
             @pulumi.runtime.test
             def it_uses_the_clusters_resource_id(sut, autoscaling_out_policy):
-                resource_id = f"service/{sut.project_stack}/{sut.project_stack}-worker"
+                resource_id = f"service/{sut.namespace}/{sut.namespace}-worker"
                 return assert_output_equals(autoscaling_out_policy.resource_id, resource_id)
 
             @pulumi.runtime.test


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-3135)

## Purpose 
<!-- what/why -->
So that we can use the RailsComponent several times in one project/stack, we need to be able to use a custom namespace throughout our stack.

## Approach 
<!-- how -->
Add a namespace attribute in all the relevant places.

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Tested with unit tests and also ensured that repo dashboard did not change names.