### PR TITLE
BEL-3173 Don't try to skip tests without output

### DIFF
--- a/.github/workflows/rspec-test.yml
+++ b/.github/workflows/rspec-test.yml
@@ -102,4 +102,7 @@ jobs:
           wget 'https://raw.githubusercontent.com/StrongMind/public-reusable-workflows/main/scripts/parse_rspec_json_output.py'
   
       - name: Check for skipped tests
-        run: python ${{ github.workspace }}/parse_rspec_json_output.py ${{ github.workspace }}/rspec_output.json
+        run: |
+          if [ -f ${{ github.workspace }}/rspec_output.json ]; then
+            python ${{ github.workspace }}/parse_rspec_json_output.py ${{ github.workspace }}/rspec_output.json
+          fi


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/TEAM-NUMBER)

## Purpose 
<!-- what/why -->
With parallel tests we don't always get the rspec_output.json which breaks our skipped test check.

## Approach 
<!-- how -->
Don't run skipped test check if we don't have that file.