### PR TITLE
BEL-3173: Remove macos and docker step

### DIFF
--- a/.github/workflows/rspec-test.yml
+++ b/.github/workflows/rspec-test.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   run-tests:
-    runs-on: macos-13
+    runs-on: ubuntu-latest
     services:
       postgres:
         image: postgres:latest
@@ -34,11 +34,6 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-      - name: Install docker
-        run: |
-          brew install docker
-          colima start
-
       - name: Check out repository
         uses: actions/checkout@v4
       


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-3173)

## Purpose 
<!-- what/why -->
Trying manual install of docker for macos didn't work.

## Approach 
<!-- how -->
Go back to ubuntu for now.