### PR TITLE
BEL-4481 Use github actions cache for ruby bundle installs when running rspec

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -114,7 +114,7 @@ jobs:
 
   rspec-test:
     name: Rspec test to code coverage
-    uses: Strongmind/public-reusable-workflows/.github/workflows/rspec-test.yml@BEL-4481-try-caching-ruby-bundles-for-tests
+    uses: Strongmind/public-reusable-workflows/.github/workflows/rspec-test.yml@main
     with:
       bundle-no-assets: ${{ inputs.bundle-no-assets }}
       ruby-version: ${{ inputs.ruby-version }}


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-4481)

## Purpose 
<!-- what/why -->
Improve the speed of build and deployment, so that our teams have a faster feedback cycle.
## Approach 
<!-- how -->
Use the ruby-setup actions caching.

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Testing via github actions.
