### PR TITLE
(B) BEL-3174 Speed up deployments

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -467,7 +467,7 @@ class ContainerComponent(pulumi.ComponentResource):
                 matcher="200",
                 interval=30,
                 timeout=5,
-                healthy_threshold=5,
+                healthy_threshold=2,
                 unhealthy_threshold=2,
             ),
         )

--- a/deployment/src/tests/test_container.py
+++ b/deployment/src/tests/test_container.py
@@ -346,7 +346,7 @@ def describe_container():
 
                 @pulumi.runtime.test
                 def it_sets_the_target_group_health_check_healthy_threshold(sut):
-                    return assert_output_equals(sut.target_group.health_check.healthy_threshold, 5)
+                    return assert_output_equals(sut.target_group.health_check.healthy_threshold, 2)
 
                 @pulumi.runtime.test
                 def it_sets_the_target_group_health_check_unhealthy_threshold(sut):


### PR DESCRIPTION

[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-3174)

## Purpose 
<!-- what/why -->
Speed up deployments ( save 1.5 minutes on health checks ).

## Approach 
<!-- how -->
When we deploy, we're currently waiting 5 * 30 seconds to confirm a deployed container as good. In order to speed that up, we reduce it to 2 * 30 seconds.

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Unit tested

## Screenshots/Video
<!-- show before/after of the change if possible -->
