### PR TITLE
BEL-4477 Use allkeys-lru for cache redis

### DIFF
--- a/deployment/src/strongmind_deployment/redis.py
+++ b/deployment/src/strongmind_deployment/redis.py
@@ -89,5 +89,10 @@ class CacheComponent(RedisComponent):
             f"{name}-parameter-group",
             name=kwargs['parameter_group_name'],
             family="redis7",
+            parameters=[
+                aws.elasticache.ParameterGroupParameterArgs(
+                    name="maxmemory-policy",
+                    value="allkeys-lru")
+            ]
         )
         super().__init__(name, opts, **kwargs)

--- a/deployment/src/tests/test_redis.py
+++ b/deployment/src/tests/test_redis.py
@@ -211,7 +211,7 @@ def describe_a_pulumi_redis_component():
                 assert isinstance(sut.parameter_group, pulumi_aws.elasticache.ParameterGroup)
                 return assert_output_equals(sut.parameter_group.name, f"{namespace}-cache-redis7")
 
-        #@pulumi.runtime.test
-        #def it_sets_the_cache_eviction_policy_to_volatile_lru(sut):
-        #    assert_output_equals(sut.parameter_group.parameters[0].name, "maxmemory-policy")
-        #    assert_output_equals(sut.parameter_group.parameters[0].value, "volatile-lru")
+        @pulumi.runtime.test
+        def it_sets_the_cache_eviction_policy_to_allkeys_lru(sut):
+           assert_output_equals(sut.parameter_group.parameters[0].name, "maxmemory-policy")
+           assert_output_equals(sut.parameter_group.parameters[0].value, "allkeys-lru")


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-4477)

## Purpose 
<!-- what/why -->
We are seeing redis run out of memory especially in canvas instances. volitile-lru will only evict keys with ttl previously set, but we expect all keys to be evicted if necessary.

## Approach 
<!-- how -->
Use allkeys-lru

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Uncommented and adjusted unit test

## Screenshots/Video
<!-- show before/after of the change if possible -->
<img width="633" alt="image" src="https://github.com/user-attachments/assets/8717f3e7-5bff-4fb7-b036-9696f435e348">
<img width="637" alt="image" src="https://github.com/user-attachments/assets/58f521fd-706a-4c98-9681-929aee3d152f">
