### PR TITLE
Bel 4546 Allow Pulumi to Deploy Autoscaling Resources on Initial Deploys

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -307,7 +307,7 @@ class ContainerComponent(pulumi.ComponentResource):
             task_definition_args=self.task_definition_args,
             deployment_maximum_percent=self.deployment_maximum_percent,
             tags=self.tags,
-            opts=pulumi.ResourceOptions(parent=self),
+            opts=pulumi.ResourceOptions(parent=self, ignore_changes=["desired_count"]),
         )
 
         if self.kwargs.get('autoscale'):

--- a/deployment/src/strongmind_deployment/worker_autoscale.py
+++ b/deployment/src/strongmind_deployment/worker_autoscale.py
@@ -35,6 +35,9 @@ class WorkerAutoscaleComponent(pulumi.ComponentResource):
             resource_id=f"service/{self.namespace}/{self.namespace}-worker",
             scalable_dimension="ecs:service:DesiredCount",
             service_namespace="ecs",
+            opts=pulumi.ResourceOptions(
+                parent=self,
+            )
         )
         self.worker_autoscaling_out_policy = aws.appautoscaling.Policy(
             qualify_component_name("worker_autoscaling_out_policy", self.kwargs),
@@ -58,6 +61,9 @@ class WorkerAutoscaleComponent(pulumi.ComponentResource):
                         scaling_adjustment=1,
                     )
                 ],
+            ),
+            opts=pulumi.ResourceOptions(
+                parent=self,
             )
         )
 
@@ -75,7 +81,10 @@ class WorkerAutoscaleComponent(pulumi.ComponentResource):
             period=60,
             statistic="Maximum",
             threshold=self.scaling_threshold,
-            alarm_actions=[self.worker_autoscaling_out_policy.arn]
+            alarm_actions=[self.worker_autoscaling_out_policy.arn],
+            opts=pulumi.ResourceOptions(
+                parent=self,
+            )
         )
 
         self.worker_queue_latency_alarm = aws.cloudwatch.MetricAlarm(
@@ -93,7 +102,10 @@ class WorkerAutoscaleComponent(pulumi.ComponentResource):
             statistic="Maximum",
             threshold=self.alert_threshold,
             alarm_actions=[self.sns_topic_arn],
-            ok_actions=[self.sns_topic_arn]
+            ok_actions=[self.sns_topic_arn],
+            opts=pulumi.ResourceOptions(
+                parent=self,
+            )
         )
 
         self.worker_autoscaling_in_policy = aws.appautoscaling.Policy(
@@ -113,6 +125,9 @@ class WorkerAutoscaleComponent(pulumi.ComponentResource):
                         scaling_adjustment=-1,
                     )
                 ],
+            ),
+            opts=pulumi.ResourceOptions(
+                parent=self,
             )
         )
 
@@ -130,7 +145,10 @@ class WorkerAutoscaleComponent(pulumi.ComponentResource):
             period=60,
             statistic="Maximum",
             threshold=self.scaling_threshold,
-            alarm_actions=[self.worker_autoscaling_in_policy.arn]
+            alarm_actions=[self.worker_autoscaling_in_policy.arn],
+            opts=pulumi.ResourceOptions(
+                parent=self,
+            )
         )
 
         self.register_outputs({})


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-4546)

## Purpose 
<!-- what/why -->
To allow autoscaling components to build on initial pulumi deploy
## Approach 
<!-- how -->
Add `opts=pulumi.ResourceOptions` with parent and depends on params to autoscaling resources
## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Deployed a test environment on repository-dashboard locally and verified good deploy with autoscale=true and worker_autoscale=true.
An initial subsequent deploy to existing infrastructure will tear down and rebuild autoscaling resources.