### PR TITLE
Bel 4546 Allow canvas autoscaling

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -314,6 +314,7 @@ class ContainerComponent(pulumi.ComponentResource):
             self.autoscaling()
         if self.kwargs.get('worker_autoscale'):
             self.worker_autoscaling = WorkerAutoscaleComponent(qualify_component_name("worker-autoscale", self.kwargs),
+                                                               fargate_service=self.fargate_service,
                                                                opts=pulumi.ResourceOptions(
                                                                    parent=self,
                                                                    depends_on=[self.fargate_service]
@@ -324,11 +325,13 @@ class ContainerComponent(pulumi.ComponentResource):
 
     def autoscaling(self):
 
+        fargate_service_id = self.fargate_service.service.id.apply(lambda x: x.split(":")[-1])
+
         self.autoscaling_target = aws.appautoscaling.Target(
             qualify_component_name("autoscaling_target", self.kwargs),
             max_capacity=self.max_capacity,
             min_capacity=self.desired_count,
-            resource_id=f"service/{self.namespace}/{self.namespace}",
+            resource_id=fargate_service_id,
             scalable_dimension="ecs:service:DesiredCount",
             service_namespace="ecs",
             opts=pulumi.ResourceOptions(

--- a/deployment/src/strongmind_deployment/worker_autoscale.py
+++ b/deployment/src/strongmind_deployment/worker_autoscale.py
@@ -12,6 +12,7 @@ class WorkerAutoscaleComponent(pulumi.ComponentResource):
         :key worker_autoscale_threshold: The threshold for the worker autoscaling policy. Default is 3.
         """
         super().__init__('strongmind:global_build:commons:worker-autoscale', name, None, opts)
+        self.fargate_service = kwargs.get('fargate_service')
         self.worker_autoscaling_in_alarm = None
         self.worker_autoscaling_in_policy = None
         self.worker_queue_latency_alarm = None
@@ -28,11 +29,14 @@ class WorkerAutoscaleComponent(pulumi.ComponentResource):
         self.worker_autoscaling()
 
     def worker_autoscaling(self):
+
+        fargate_service_id = self.fargate_service.service.id.apply(lambda x: x.split(":")[-1])
+
         self.worker_autoscaling_target = aws.appautoscaling.Target(
             qualify_component_name("worker_autoscaling_target", self.kwargs),
             max_capacity=self.worker_max_capacity,
             min_capacity=self.worker_min_capacity,
-            resource_id=f"service/{self.namespace}/{self.namespace}-worker",
+            resource_id=fargate_service_id,
             scalable_dimension="ecs:service:DesiredCount",
             service_namespace="ecs",
             opts=pulumi.ResourceOptions(

--- a/deployment/src/tests/a_pulumi_containerized_app.py
+++ b/deployment/src/tests/a_pulumi_containerized_app.py
@@ -1,0 +1,145 @@
+import os
+
+import pytest
+from tests.mocks import get_pulumi_mocks
+
+
+def a_pulumi_containerized_app():
+    @pytest.fixture
+    def app_name(faker):
+        return faker.word()
+
+    @pytest.fixture
+    def environment(faker):
+        os.environ["ENVIRONMENT_NAME"] = faker.word()
+        return os.environ["ENVIRONMENT_NAME"]
+
+    @pytest.fixture
+    def stack(environment):
+        return environment
+
+
+    @pytest.fixture
+    def pulumi_mocks(faker):
+        return get_pulumi_mocks(faker)
+
+    @pytest.fixture
+    def app_path(faker):
+        return f'./{faker.word()}'
+
+    @pytest.fixture
+    def container_port(faker):
+        return faker.random_int()
+
+    @pytest.fixture
+    def cpu(faker):
+        return faker.random_int()
+
+    @pytest.fixture
+    def memory(faker):
+        return faker.random_int()
+
+    @pytest.fixture
+    def entry_point(faker):
+        return f'./{faker.word()}'
+
+    @pytest.fixture
+    def command(faker):
+        return f'./{faker.word()}'
+
+    @pytest.fixture
+    def aws_account_id(faker):
+        return faker.random_int()
+
+    @pytest.fixture
+    def container_image(aws_account_id, app_name):
+        return f"{aws_account_id}.dkr.ecr.us-west-2.amazonaws.com/{app_name}:latest"
+
+    @pytest.fixture
+    def env_vars(faker, environment):
+        return {
+            "ENVIRONMENT_NAME": environment,
+        }
+
+    @pytest.fixture
+    def secrets(faker):
+        return [{
+            faker.word(): faker.password(),
+        }]
+
+    @pytest.fixture
+    def zone_id(faker):
+        return faker.word()
+
+    @pytest.fixture
+    def load_balancer_dns_name(faker):
+        return f"{faker.word()}.{faker.word()}.{faker.word()}"
+
+    @pytest.fixture
+    def resource_record_name(faker):
+        return f"{faker.word()}.{faker.word()}.{faker.word()}"
+
+    @pytest.fixture
+    def resource_record_value(faker):
+        return f"{faker.word()}.{faker.word()}.{faker.word()}"
+
+    @pytest.fixture
+    def resource_record_type(faker):
+        return faker.word()
+
+    @pytest.fixture
+    def domain_validation_options(faker, resource_record_name, resource_record_value, resource_record_type):
+        class FakeValidationOption:
+            def __init__(self, name, value, type):
+                self.resource_record_name = name
+                self.resource_record_value = value
+                self.resource_record_type = type
+
+            pass
+
+        return [FakeValidationOption(resource_record_name, resource_record_value, resource_record_type)]
+
+    @pytest.fixture
+    def need_load_balancer():
+        return True
+
+    @pytest.fixture
+    def component_kwargs(pulumi_set_mocks,
+                         app_name,
+                         app_path,
+                         container_port,
+                         cpu,
+                         memory,
+                         entry_point,
+                         command,
+                         container_image,
+                         env_vars,
+                         secrets,
+                         zone_id,
+                         load_balancer_dns_name,
+                         domain_validation_options,
+                         ):
+        return {
+            "app_path": app_path,
+            "container_port": container_port,
+            "cpu": cpu,
+            "memory": memory,
+            "entry_point": entry_point,
+            "command": command,
+            "container_image": container_image,
+            "env_vars": env_vars,
+            "secrets": secrets,
+            "zone_id": zone_id,
+            "load_balancer_dns_name": load_balancer_dns_name,
+            "domain_validation_options": domain_validation_options
+        }
+
+    @pytest.fixture
+    def sut(component_kwargs):
+        import strongmind_deployment.container
+        return strongmind_deployment.container.ContainerComponent("container",
+                                                                  **component_kwargs
+                                                                  )
+
+    def it_exists(sut):
+        assert sut

--- a/deployment/src/tests/mocks.py
+++ b/deployment/src/tests/mocks.py
@@ -1,9 +1,7 @@
 from concurrent.futures import ThreadPoolExecutor
-from unittest.mock import Mock
+
 import pulumi
 import pulumi_aws as aws
-import pulumi_aws.ecs
-from pulumi_aws.ecs import ServiceNetworkConfigurationArgs
 
 
 def get_pulumi_mocks(faker, fake_password=None, secret_string="{}"):
@@ -25,6 +23,11 @@ def get_pulumi_mocks(faker, fake_password=None, secret_string="{}"):
                     __slots__ = {
 
                     }
+
+
+                service_name = args.inputs["name"]
+                ecs_service_mock = aws.ecs.Service(service_name)
+
                 outputs = {
                     **args.inputs,
                     "desired_count": args.inputs["desiredCount"],
@@ -34,6 +37,7 @@ def get_pulumi_mocks(faker, fake_password=None, secret_string="{}"):
                     "enable_execute_command": args.inputs.get("enableExecuteCommand"),
                     "health_check_grace_period_seconds": args.inputs.get("healthCheckGracePeriodSeconds"),
                     "deployment_maximum_percent": args.inputs.get("deploymentMaximumPercent"),
+                    "service": ecs_service_mock
                 }
             if args.typ == "aws:rds/cluster:Cluster":
                 outputs = {
@@ -125,6 +129,12 @@ def get_pulumi_mocks(faker, fake_password=None, secret_string="{}"):
                     "arn": f"arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/{faker.word()}",
                     "name": f"loadbalancer-{faker.word()}",
                 }
+            if args.typ == "aws:ecs/service:Service":
+                arn = f"arn:aws:ecs:us-west-2:123456789012:service/{args.name}/{args.name}"
+                outputs = {
+                    **args.inputs
+                }
+                return [arn, outputs]
 
             return [args.name + '_id', outputs]
 

--- a/deployment/src/tests/test_container_autoscaling.py
+++ b/deployment/src/tests/test_container_autoscaling.py
@@ -5,7 +5,7 @@ import pytest
 from pytest_describe import behaves_like
 
 from tests.shared import assert_output_equals, assert_outputs_equal
-from tests.test_container import a_pulumi_containerized_app
+from tests.a_pulumi_containerized_app import a_pulumi_containerized_app
 
 
 @behaves_like(a_pulumi_containerized_app)

--- a/deployment/src/tests/test_container_autoscaling.py
+++ b/deployment/src/tests/test_container_autoscaling.py
@@ -1,3 +1,5 @@
+import random
+
 import pulumi
 import pytest
 from pytest_describe import behaves_like
@@ -42,8 +44,8 @@ def describe_autoscaling():
 
         @pulumi.runtime.test
         def it_uses_the_clusters_resource_id(sut):
-            resource_id = f"service/{sut.namespace}/{sut.namespace}"
-            return assert_output_equals(sut.autoscaling_target.resource_id, resource_id)
+            service_id = sut.fargate_service.service.id.apply(lambda x: x.split(":")[-1])
+            return assert_outputs_equal(sut.autoscaling_target.resource_id, service_id)
 
         def describe_running_tasks_alarm():
             @pulumi.runtime.test
@@ -143,6 +145,21 @@ def describe_autoscaling():
             def it_triggers_when_the_threshold_crosses_5(sut):
                 return assert_output_equals(sut.autoscaling_out_alarm.threshold, 5)
 
+            def describe_when_using_a_custom_threshold():
+                @pytest.fixture
+                def autoscale_threshold():
+                    return random.randint(6, 15)
+
+                @pytest.fixture
+                def component_kwargs(component_kwargs, autoscale_threshold):
+                    component_kwargs["autoscale_threshold"] = autoscale_threshold
+                    return component_kwargs
+
+                @pulumi.runtime.test
+                def it_triggers_when_the_threshold_crosses_the_custom_value(sut, autoscale_threshold):
+                    return assert_output_equals(sut.autoscaling_out_alarm.threshold, autoscale_threshold)
+
+
             @pulumi.runtime.test
             def it_treats_missing_data_as_missing(sut):
                 return assert_output_equals(sut.autoscaling_out_alarm.treat_missing_data, "missing")
@@ -217,6 +234,20 @@ def describe_autoscaling():
             @pulumi.runtime.test
             def it_triggers_when_the_threshold_crosses_5(sut):
                 return assert_output_equals(sut.autoscaling_in_alarm.threshold, 5)
+
+            def describe_when_using_a_custom_threshold():
+                @pytest.fixture
+                def autoscale_threshold():
+                    return random.randint(6, 15)
+
+                @pytest.fixture
+                def component_kwargs(component_kwargs, autoscale_threshold):
+                    component_kwargs["autoscale_threshold"] = autoscale_threshold
+                    return component_kwargs
+
+                @pulumi.runtime.test
+                def it_triggers_when_the_threshold_crosses_the_custom_value(sut, autoscale_threshold):
+                    return assert_output_equals(sut.autoscaling_in_alarm.threshold, autoscale_threshold)
 
             @pulumi.runtime.test
             def it_treats_missing_data_as_missing(sut):

--- a/deployment/src/tests/test_worker_container_autoscaling.py
+++ b/deployment/src/tests/test_worker_container_autoscaling.py
@@ -63,8 +63,8 @@ def describe_worker_autoscaling():
 
         @pulumi.runtime.test
         def it_uses_the_clusters_resource_id(sut, autoscaling_target):
-            resource_id = f"service/{sut.namespace}/{sut.namespace}-worker"
-            return assert_output_equals(autoscaling_target.resource_id, resource_id)
+            service_id = sut.fargate_service.service.id.apply(lambda x: x.split(":")[-1])
+            return assert_outputs_equal(autoscaling_target.resource_id, service_id)
 
         def describe_autoscaling_out_alarm():
             @pulumi.runtime.test
@@ -235,8 +235,8 @@ def describe_worker_autoscaling():
 
             @pulumi.runtime.test
             def it_uses_the_clusters_resource_id(sut, autoscaling_in_policy):
-                resource_id = f"service/{sut.namespace}/{sut.namespace}-worker"
-                return assert_output_equals(autoscaling_in_policy.resource_id, resource_id)
+                service_id = sut.fargate_service.service.id.apply(lambda x: x.split(":")[-1])
+                return assert_outputs_equal(autoscaling_in_policy.resource_id, service_id)
 
             @pulumi.runtime.test
             def it_has_a_default_scalable_dimension_of_desired_count(autoscaling_in_policy):
@@ -304,8 +304,8 @@ def describe_worker_autoscaling():
 
             @pulumi.runtime.test
             def it_uses_the_clusters_resource_id(sut, autoscaling_out_policy):
-                resource_id = f"service/{sut.namespace}/{sut.namespace}-worker"
-                return assert_output_equals(autoscaling_out_policy.resource_id, resource_id)
+                service_id = sut.fargate_service.service.id.apply(lambda x: x.split(":")[-1])
+                return assert_outputs_equal(autoscaling_out_policy.resource_id, service_id)
 
             @pulumi.runtime.test
             def it_has_a_default_scalable_dimension_of_desired_count(autoscaling_out_policy):

--- a/deployment/src/tests/test_worker_container_autoscaling.py
+++ b/deployment/src/tests/test_worker_container_autoscaling.py
@@ -3,7 +3,7 @@ import pytest
 from pytest_describe import behaves_like
 
 from tests.shared import assert_output_equals, assert_outputs_equal
-from tests.test_container import a_pulumi_containerized_app
+from tests.a_pulumi_containerized_app import a_pulumi_containerized_app
 
 
 @behaves_like(a_pulumi_containerized_app)


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-4546)

## Purpose 
<!-- what/why -->
Allow canvas autoscaling
## Approach 
<!-- how -->
Change pulumi configuration to get the service id from ecs instead of predefining it - because we were reconstructing it before, rather than getting it, when we started building things with different cluster IDs, that failed.

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Unit testing and pulumi previews.
