### PR TITLE
Bel 3136  add alarm for canvas autoscale

### DIFF
--- a/deployment/src/strongmind_deployment/worker_autoscale.py
+++ b/deployment/src/strongmind_deployment/worker_autoscale.py
@@ -25,9 +25,9 @@ class WorkerAutoscaleComponent(pulumi.ComponentResource):
         self.scaling_threshold = kwargs.get('max_queue_latency_threshold', 60)
         self.alert_threshold = kwargs.get('alert_threshold', 18000)
         self.sns_topic_arn = kwargs.get('sns_topic_arn')
-        self.worker_autoscaling()
         self.canvas = kwargs.get("namespace", False)
         self.metric_name = "JobStaleness" if self.canvas else "MaxQueueLatency"
+        self.worker_autoscaling()
 
 
     def worker_autoscaling(self):

--- a/deployment/src/strongmind_deployment/worker_autoscale.py
+++ b/deployment/src/strongmind_deployment/worker_autoscale.py
@@ -26,6 +26,9 @@ class WorkerAutoscaleComponent(pulumi.ComponentResource):
         self.alert_threshold = kwargs.get('alert_threshold', 18000)
         self.sns_topic_arn = kwargs.get('sns_topic_arn')
         self.worker_autoscaling()
+        self.canvas = kwargs.get("namespace", False)
+        self.metric_name = "JobStaleness" if self.canvas else "MaxQueueLatency"
+
 
     def worker_autoscaling(self):
         self.worker_autoscaling_target = aws.appautoscaling.Target(
@@ -72,7 +75,7 @@ class WorkerAutoscaleComponent(pulumi.ComponentResource):
             name=f"{self.namespace}-worker-auto-scaling-out-alarm",
             comparison_operator="GreaterThanThreshold",
             evaluation_periods=1,
-            metric_name="MaxQueueLatency",
+            metric_name=self.metric_name,
             unit="Seconds",
             dimensions={
                 "QueueName": "AllQueues"
@@ -92,7 +95,7 @@ class WorkerAutoscaleComponent(pulumi.ComponentResource):
             name=f"{self.namespace}-worker-queue-latency-alarm",
             comparison_operator="GreaterThanThreshold",
             evaluation_periods=1,
-            metric_name="MaxQueueLatency",
+            metric_name=self.metric_name,
             unit="Seconds",
             dimensions={
                 "QueueName": "AllQueues"
@@ -136,7 +139,7 @@ class WorkerAutoscaleComponent(pulumi.ComponentResource):
             name=f"{self.namespace}-worker-auto-scaling-in-alarm",
             comparison_operator="LessThanOrEqualToThreshold",
             evaluation_periods=5,
-            metric_name="MaxQueueLatency",
+            metric_name=self.metric_name,
             unit="Seconds",
             dimensions={
                 "QueueName": "AllQueues"

--- a/deployment/src/tests/test_worker_container_autoscaling.py
+++ b/deployment/src/tests/test_worker_container_autoscaling.py
@@ -92,6 +92,16 @@ def describe_worker_autoscaling():
             def it_has_the_metric_name_of_max_queue_latency(autoscaling_out_alarm):
                 return assert_output_equals(autoscaling_out_alarm.metric_name, "MaxQueueLatency")
 
+            def describe_when_canvas_is_true():
+                @pytest.fixture
+                def component_kwargs(component_kwargs):
+                    component_kwargs["namespace"] = "new_canvas"
+                    return component_kwargs
+
+                @pulumi.runtime.test
+                def it_has_the_metric_name_of_job_staleness(autoscaling_out_alarm):
+                    return assert_output_equals(autoscaling_out_alarm.metric_name, "JobStaleness")
+
             @pulumi.runtime.test
             def it_has_the_unit_of_seconds(autoscaling_out_alarm):
                 return assert_output_equals(autoscaling_out_alarm.unit, "Seconds")
@@ -141,6 +151,16 @@ def describe_worker_autoscaling():
             @pulumi.runtime.test
             def it_has_the_metric_name_of_max_queue_latency(queue_latency_alarm):
                 return assert_output_equals(queue_latency_alarm.metric_name, "MaxQueueLatency")
+
+            def describe_when_canvas_is_true():
+                @pytest.fixture
+                def component_kwargs(component_kwargs):
+                    component_kwargs["namespace"] = "new_canvas"
+                    return component_kwargs
+
+                @pulumi.runtime.test
+                def it_has_the_metric_name_of_job_staleness(queue_latency_alarm):
+                    return assert_output_equals(queue_latency_alarm.metric_name, "JobStaleness")
 
             @pulumi.runtime.test
             def it_has_the_unit_of_seconds(queue_latency_alarm):
@@ -194,6 +214,16 @@ def describe_worker_autoscaling():
             @pulumi.runtime.test
             def it_has_the_metric_name_of_max_queue_latency(autoscaling_in_alarm):
                 return assert_output_equals(autoscaling_in_alarm.metric_name, "MaxQueueLatency")
+
+            def describe_when_canvas_is_true():
+                @pytest.fixture
+                def component_kwargs(component_kwargs):
+                    component_kwargs["namespace"] = "new_canvas"
+                    return component_kwargs
+
+                @pulumi.runtime.test
+                def it_has_the_metric_name_of_job_staleness(autoscaling_in_alarm):
+                    return assert_output_equals(autoscaling_in_alarm.metric_name, "JobStaleness")
 
             @pulumi.runtime.test
             def it_has_the_unit_of_seconds(autoscaling_in_alarm):


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-3136)

## Purpose 
<!-- what/why -->
Scale canvas workers using the JobStaleness metric
## Approach 
<!-- how -->
Use correct metric_name if canvas instance is being deployed 
## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Added tests for metric_name
Verified locally with no breaking changes to repo-dashboard

