### PR TITLE
BEL-4567 Update the running task alarm to allow for canvas variation

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -449,15 +449,19 @@ class ContainerComponent(pulumi.ComponentResource):
             )
         )
 
+        cluster_name = self.ecs_cluster_arn.apply(
+            lambda arn: arn.split("/")[-1]
+        )
+
         self.running_tasks_alarm = aws.cloudwatch.MetricAlarm(
             qualify_component_name("running_tasks_alarm", self.kwargs),
             name=f"{self.namespace}-running-tasks-alarm",
-            comparison_operator="GreaterThanThreshold",
+            comparison_operator="GreaterThanOrEqualToThreshold",
             evaluation_periods=1,
             metric_name="RunningTaskCount",
             namespace="ECS/ContainerInsights",
             dimensions={
-                "ClusterName": self.namespace,
+                "ClusterName": cluster_name,
                 "ServiceName": self.namespace
             },
             period=60,

--- a/deployment/src/tests/a_pulumi_containerized_app.py
+++ b/deployment/src/tests/a_pulumi_containerized_app.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 from tests.mocks import get_pulumi_mocks
+import pulumi
 
 
 def a_pulumi_containerized_app():
@@ -88,6 +89,10 @@ def a_pulumi_containerized_app():
         return faker.word()
 
     @pytest.fixture
+    def ecs_cluster_arn():
+        return pulumi.Output.from_input("arn:aws:ecs:us-west-2:123456789012:cluster/my-cluster")
+
+    @pytest.fixture
     def domain_validation_options(faker, resource_record_name, resource_record_value, resource_record_type):
         class FakeValidationOption:
             def __init__(self, name, value, type):
@@ -117,6 +122,7 @@ def a_pulumi_containerized_app():
                          secrets,
                          zone_id,
                          load_balancer_dns_name,
+                         ecs_cluster_arn,
                          domain_validation_options,
                          ):
         return {
@@ -131,6 +137,7 @@ def a_pulumi_containerized_app():
             "secrets": secrets,
             "zone_id": zone_id,
             "load_balancer_dns_name": load_balancer_dns_name,
+            "ecs_cluster_arn": ecs_cluster_arn,
             "domain_validation_options": domain_validation_options
         }
 

--- a/deployment/src/tests/test_container_autoscaling.py
+++ b/deployment/src/tests/test_container_autoscaling.py
@@ -58,7 +58,7 @@ def describe_autoscaling():
 
             @pulumi.runtime.test
             def it_triggers_when_greater_than_threshold(sut):
-                return assert_output_equals(sut.running_tasks_alarm.comparison_operator, "GreaterThanThreshold")
+                return assert_output_equals(sut.running_tasks_alarm.comparison_operator, "GreaterThanOrEqualToThreshold")
 
             @pulumi.runtime.test
             def it_evaluates_for_one_period(sut):


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-4567)

## Purpose 
<!-- what/why -->
Fix the running task alarm for canvas
## Approach 
<!-- how -->
Use the cluster name from the ecs cluster instead of namespace
## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Pulumi deploy locally and verified
## Screenshots/Video
<!-- show before/after of the change if possible -->
![image](https://github.com/user-attachments/assets/b2c73917-9b46-4a45-8254-8c9e83aaf00e)
