### PR TITLE
BEL-4567 Fix running task alarm for Canvas

### DIFF
--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -182,7 +182,7 @@ class RailsComponent(pulumi.ComponentResource):
 
     def ecs(self):
         self.ecs_cluster = create_ecs_cluster(self, self.namespace, self.kwargs)
-        self.kwargs['ecs_cluster_arn'] = self.ecs_cluster.arn
+        self.kwargs['ecs_cluster'] = self.ecs_cluster
 
         container_image = os.environ['CONTAINER_IMAGE']
         master_key = os.environ['RAILS_MASTER_KEY']

--- a/deployment/src/tests/test_container.py
+++ b/deployment/src/tests/test_container.py
@@ -417,7 +417,7 @@ def describe_container():
                     assert service_cluster == cluster
 
                 return pulumi.Output.all(sut.fargate_service.cluster,
-                                         sut.ecs_cluster.arn).apply(check_cluster)
+                                          sut.ecs_cluster.arn).apply(check_cluster)
 
             @pulumi.runtime.test
             def it_has_task_definition(sut, container_port, cpu, memory, entry_point, command, stack, app_name,
@@ -590,20 +590,21 @@ def describe_container():
 
     def describe_with_existing_cluster():
         @pytest.fixture
-        def existing_cluster_arn(faker):
-            return faker.word()
+        def existing_cluster():
+            import pulumi_aws as aws
+            return aws.ecs.Cluster("existing-cluster")
 
         @pytest.fixture
-        def sut(component_kwargs, existing_cluster_arn):
+        def sut(component_kwargs, existing_cluster):
             component_kwargs["need_load_balancer"] = False
-            component_kwargs["ecs_cluster_arn"] = existing_cluster_arn
+            component_kwargs["ecs_cluster"] = existing_cluster
             import strongmind_deployment.container
             return strongmind_deployment.container.ContainerComponent("container",
                                                                       **component_kwargs)
 
         @pulumi.runtime.test
-        def it_uses_existing_cluster(sut, existing_cluster_arn):
-            return assert_output_equals(sut.fargate_service.cluster, existing_cluster_arn)
+        def it_uses_existing_cluster(sut, existing_cluster):
+            assert sut.ecs_cluster == existing_cluster
 
     def describe_logs():
         @pulumi.runtime.test

--- a/deployment/src/tests/test_container_autoscaling.py
+++ b/deployment/src/tests/test_container_autoscaling.py
@@ -57,8 +57,8 @@ def describe_autoscaling():
                 return assert_output_equals(sut.running_tasks_alarm.name, f"{app_name}-{stack}-running-tasks-alarm")
 
             @pulumi.runtime.test
-            def it_triggers_when_greater_than_threshold(sut):
-                return assert_output_equals(sut.running_tasks_alarm.comparison_operator, "GreaterThanThreshold")
+            def it_triggers_when_greater_than_or_equal_to_threshold(sut):
+                return assert_output_equals(sut.running_tasks_alarm.comparison_operator, "GreaterThanOrEqualToThreshold")
 
             @pulumi.runtime.test
             def it_evaluates_for_one_period(sut):


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-4567)

## Purpose 
<!-- what/why -->
To allow the proper dimensions for canvas in the running task alarm
## Approach 
<!-- how -->
Because we were constructing the name and using the namespace we ended up doubling up the names for canvas components. Instead of using the namespace to guess what the cluster is called, we change to sending the actual cluster to the ContainerComponent. We also fixed the comparison_operator so that we will alarm when the threshold is met because we intended to alarm at 100 not 101
## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Unit test
