### PR TITLE
(I) TH-1: Run rspec tests with RAILS_ENV=test

### DIFF
--- a/.github/workflows/rspec-test.yml
+++ b/.github/workflows/rspec-test.yml
@@ -221,7 +221,7 @@ jobs:
       - name: Test
         if: ${{ steps.secret-check.outputs.available != 'true' && inputs.run-parallel == false }}
         run: |
-          bundle exec rspec --format documentation --format json --out ${{ github.workspace }}/rspec_output.json
+          RAILS_ENV=test bundle exec rspec --format documentation --format json --out ${{ github.workspace }}/rspec_output.json
 
       - name: Test & publish code coverage
         uses: paambaati/codeclimate-action@v5.0.0


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/TH-1)

## Purpose 
<!-- what/why -->
So that tests run in the test environment, and tests that use Sidekiq do not try to connect
to a real Redis server.

## Approach 
<!-- how -->
append `RAILS_ENV=test` to `bundle exec rspec` command

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
N/A

## Screenshots/Video
<!-- show before/after of the change if possible -->
<img width="1036" alt="image" src="https://github.com/user-attachments/assets/8a1c17b8-c370-426a-a0c9-f974fd9d5116" />

