### PR TITLE
BEL-4242 Update Documentation for New Rails Deployements

### DIFF
--- a/docs/rails-app-deployment.md
+++ b/docs/rails-app-deployment.md
@@ -29,14 +29,6 @@ This ensures that your local postgres server will have the correct database name
 1. Paste the contents of the `config/master.key` file into the value field.
 1. Click on `Add secret`.
 
-## Turn off autoscaling for first deploy
-(Belding plans to fix this soon)
-1. Open the `infrastructure/__main__.py` file.
-1. Edit the second line to be the following:
-```python
-component = RailsComponent("rails", autoscale=False)
-```
-3. Save the file, commit and push.
 
 ## Check Deployment
 1. Push or merge your changes to the main branch.
@@ -80,7 +72,3 @@ component = RailsComponent("rails", autoscale=False)
 1. Click on the `Deploy to production` workflow.
 1. Click on `Run workflow` on the right.
 1. Click on the green `Run workflow` button.
-
-## Autoscaling
-
-Remove `autoscale=false` from the `infrastructure/__main__.py` file and redeploy.


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-4242)

## Purpose 
<!-- what/why -->
Update the documentation to exclude the need to set autoscale to false on initial deploy as we have fixed this bug.
## Approach 
<!-- how -->
This pull request includes changes to the `docs/rails-app-deployment.md` file to update the deployment documentation. The most important changes involve the removal of outdated instructions related to autoscaling.

Documentation updates:

* Removed the section on turning off autoscaling for the first deploy, including instructions to edit the `infrastructure/__main__.py` file.
* Removed the autoscaling section that instructed users to remove `autoscale=false` from the `infrastructure/__main__.py` file and redeploy.
