### PR TITLE
BEL-4715 Adjust the target response time scaling metric to be p95

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -386,7 +386,7 @@ class ContainerComponent(pulumi.ComponentResource):
             alarm_actions=[self.autoscaling_out_policy.arn],
             metric_name="TargetResponseTime",
             namespace="AWS/ApplicationELB",
-            extended_statistic="p99",
+            extended_statistic="p95",
             dimensions={
                 "TargetGroup": target_group_dimension,
                 "LoadBalancer": load_balancer_arn,
@@ -440,7 +440,7 @@ class ContainerComponent(pulumi.ComponentResource):
             treat_missing_data="missing",
             metric_name="TargetResponseTime",
             namespace="AWS/ApplicationELB",
-            extended_statistic="p99",
+            extended_statistic="p95",
             dimensions={
                 "TargetGroup": target_group_dimension,
                 "LoadBalancer": load_balancer_arn,

--- a/deployment/src/tests/test_container_autoscaling.py
+++ b/deployment/src/tests/test_container_autoscaling.py
@@ -108,8 +108,8 @@ def describe_autoscaling():
                                             "AWS/ApplicationELB")
 
             @pulumi.runtime.test
-            def it_checks_the_unit_as_a_p99(sut):
-                return assert_output_equals(sut.autoscaling_out_alarm.extended_statistic, "p99")
+            def it_checks_the_unit_as_a_p95(sut):
+                return assert_output_equals(sut.autoscaling_out_alarm.extended_statistic, "p95")
 
             @pulumi.runtime.test
             def it_pulls_the_metric_data_from_the_target_group(sut):
@@ -198,8 +198,8 @@ def describe_autoscaling():
                                             "AWS/ApplicationELB")
 
             @pulumi.runtime.test
-            def it_checks_the_unit_as_a_p99(sut):
-                return assert_output_equals(sut.autoscaling_in_alarm.extended_statistic, "p99")
+            def it_checks_the_unit_as_a_p95(sut):
+                return assert_output_equals(sut.autoscaling_in_alarm.extended_statistic, "p95")
 
             @pulumi.runtime.test
             def it_pulls_the_metric_data_from_the_target_group(sut):


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-4715)

## Purpose 
<!-- what/why -->
Enhance the scaling of central by switching from using the 99th percentile (p99) to the 95th percentile (p95) as the scaling metric, to reduce unnecessary scaling actions.
## Approach 
<!-- how -->
This pull request involves changes to the `deployment/src/strongmind_deployment/container.py` and `deployment/src/tests/test_container_autoscaling.py` files to update the extended statistic used for autoscaling from "p99" to "p95". The updates ensure that the autoscaling configuration and its corresponding tests reflect the new extended statistic.

### Autoscaling Configuration Update:

* [`deployment/src/strongmind_deployment/container.py`](diffhunk://#diff-3f9fe040f3ced4b63cc35de46baf666b286eafbe36691e7301da52ed109e1de7L389-R389): Changed the `extended_statistic` parameter from "p99" to "p95" in the `autoscaling` method to adjust the autoscaling policy. [[1]](diffhunk://#diff-3f9fe040f3ced4b63cc35de46baf666b286eafbe36691e7301da52ed109e1de7L389-R389) [[2]](diffhunk://#diff-3f9fe040f3ced4b63cc35de46baf666b286eafbe36691e7301da52ed109e1de7L443-R443)

### Test Updates:

* [`deployment/src/tests/test_container_autoscaling.py`](diffhunk://#diff-eedee2e86d724c2e478761fe77d877570c9c17e814d7f3dcafa40cda50b0f119L111-R112): Updated the test cases to check for "p95" instead of "p99" in the `it_checks_the_unit_as_a_p95` method for both `autoscaling_out_alarm` and `autoscaling_in_alarm`. [[1]](diffhunk://#diff-eedee2e86d724c2e478761fe77d877570c9c17e814d7f3dcafa40cda50b0f119L111-R112) [[2]](diffhunk://#diff-eedee2e86d724c2e478761fe77d877570c9c17e814d7f3dcafa40cda50b0f119L201-R202)


