### PR TITLE
BEL-4757 Add new workflows for interactives

### DIFF
--- a/.github/workflows/dev_upload_interactives.yml
+++ b/.github/workflows/dev_upload_interactives.yml
@@ -1,0 +1,28 @@
+name: Dev Deploy
+
+on:
+  workflow_call:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Pulling Repo Name to use as subfolder
+        run: |
+          echo "REPONAME=$(echo $GITHUB_REPOSITORY | cut -d/ -f2)" >> $GITHUB_ENV
+
+      - name: Remove Unneeded Files
+        run: |
+          rm -r .github/ .git/ 
+
+      - name: Upload to blob storage
+        uses: azure/CLI@v1
+        with:
+          azcliversion: 2.67.0
+          # azcopy workadound https://github.com/Azure/azure-cli/issues/30635
+          inlineScript: |
+              tdnf install -y azcopy;
+              az storage blob upload-batch  --source ./ --destination "\$web/${{ env.REPONAME }}/" --connection-string '${{ secrets.INTERACTIVE_CONNECTION_STRING_DEV }}'

--- a/.github/workflows/prod_upload_interactives.yml
+++ b/.github/workflows/prod_upload_interactives.yml
@@ -1,0 +1,38 @@
+name: Prod Deploy
+
+on:
+  workflow_call:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Pulling Repo Name to use as subfolder
+        run: |
+          echo "REPONAME=$(echo $GITHUB_REPOSITORY | cut -d/ -f2)" >> $GITHUB_ENV
+
+      - name: Remove Unneeded Files
+        run: |
+          rm -r .github/ .git/
+
+      - name: Upload to blob storage
+        uses: azure/CLI@v1
+        with:
+          azcliversion: 2.67.0
+          # azcopy workadound https://github.com/Azure/azure-cli/issues/30635
+          inlineScript: |
+              tdnf install -y azcopy;
+              az storage blob upload-batch  --source ./ --destination "\$web/${{ env.REPONAME }}/" --connection-string '${{ secrets.INTERACTIVE_CONNECTION_STRING_PROD }}'
+
+
+  notify_deployment:
+    name: Notify Deployment
+    needs: deploy
+    uses:
+      strongmind/public-reusable-workflows/.github/workflows/send-deployment-notification.yml@main
+    with:
+      repository_name: ${{ github.repository }}
+    secrets: inherit


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-4757)

## Purpose 
<!-- what/why -->
Fix broken pipelines for Interactives
All interactive repos will now use these workflows once the `modify-github-workflows-replace-workflows.py` script in Helpers repo is run which will update all interactives repos' workflows
## Approach 
<!-- how -->
The `az storage blob upload batch` cli command requires the copy library and this is now broken b/c MS moved its CDN from edge to front door and the `storage blob` command apparently is still trying to download the `copy` library from the old CDN. from https://github.com/Azure/azure-cli/issues/30635
Add new workflows, which includes changes to remove the broken action and replace with new action
Use new action to use the cli directly and install the copy library before calling the storage blob command
## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Validated new actions work on campaign-manager-interactive
