### PR TITLE
BEL-4831: Fix issue of ECS deployments resetting desired count of containers

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -312,7 +312,7 @@ class ContainerComponent(pulumi.ComponentResource):
             task_definition_args=self.task_definition_args,
             deployment_maximum_percent=self.deployment_maximum_percent,
             tags=self.tags,
-            opts=pulumi.ResourceOptions(parent=self),
+            opts=pulumi.ResourceOptions(parent=self, ignore_changes=["desired_count"]),
         )
 
         if self.kwargs.get('autoscale'):


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-4831)

## Purpose
This change prevents deployments from resetting scaling.

## Approach
Update the deployment logic to ignore changes to the desired count of ECS containers. 

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm -->
Josh ran with repo dashboard.
