### PR TITLE
BEL-5337 Ignore changes for desired count

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -312,7 +312,7 @@ class ContainerComponent(pulumi.ComponentResource):
             task_definition_args=self.task_definition_args,
             deployment_maximum_percent=self.deployment_maximum_percent,
             tags=self.tags,
-            opts=pulumi.ResourceOptions(parent=self, ignore_changes=["desired_count"]),
+            opts=pulumi.ResourceOptions(parent=self, ignore_changes=["desired_count", "service.desired_count", "service.desiredCount"]),
         )
 
         if self.kwargs.get('autoscale'):


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-5337)

## Purpose 
<!-- what/why -->
Fix the issue of resetting the desired count with every deploy
## Approach 
<!-- how -->
This pull request includes a small change to the `deployment/src/strongmind_deployment/container.py` file. The change involves updating the `ignore_changes` parameter in the `pulumi.ResourceOptions` to include additional fields for desired count. 

* [`deployment/src/strongmind_deployment/container.py`](diffhunk://#diff-3f9fe040f3ced4b63cc35de46baf666b286eafbe36691e7301da52ed109e1de7L315-R315): Updated the `ignore_changes` parameter to include `"service.desired_count"` and `"service.desiredCount"` in addition to `"desired_count"`.
## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Tested on new-id-sandbox