### PR TITLE
BEL-5414 Ensure that every request is forced to use HTTPS end to end

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -794,7 +794,7 @@ class ContainerComponent(pulumi.ComponentResource):
             ],
             default_cache_behavior=aws.cloudfront.DistributionDefaultCacheBehaviorArgs(
                 target_origin_id=self.load_balancer.dns_name,
-                viewer_protocol_policy="allow-all",
+                viewer_protocol_policy="redirect-to-https",
                 allowed_methods=["GET", "HEAD", "OPTIONS", "PUT", "PATCH", "POST", "DELETE"],
                 cached_methods=["GET", "HEAD"],
                 cache_policy_id=cache_policy.id,

--- a/deployment/src/tests/test_container.py
+++ b/deployment/src/tests/test_container.py
@@ -687,7 +687,7 @@ def describe_container():
                 assert behavior["target_origin_id"] == alb_dns_name
                 
                 # Check protocol policy
-                assert behavior["viewer_protocol_policy"] == "allow-all"
+                assert behavior["viewer_protocol_policy"] == "redirect-to-https"
                 
                 # Check methods
                 assert set(behavior["allowed_methods"]) == {"GET", "HEAD", "OPTIONS", "PUT", "PATCH", "POST", "DELETE"}


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-5414)

## Purpose 
<!-- what/why -->
FIx issue of users getting blocked, probably due to invalid sessions and cloudfront allowing http requests
![image](https://github.com/user-attachments/assets/015372eb-dab6-491e-9870-689afcaa19b5)

## Approach 
<!-- how -->
Change policy to force redirect to https
## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Manually changed distribution for course-builder prod and users were unable to replicate issue afterwards
