### PR TITLE
Update default ruby version to 3.2.6

### DIFF
--- a/.github/workflows/rspec-test.yml
+++ b/.github/workflows/rspec-test.yml
@@ -6,7 +6,7 @@ on:
       ruby-version:
         description: "Ruby version"
         required: false
-        default: "3.2.2"
+        default: "3.2.6"
         type: string
       bundle-no-assets:
         description: "Bundle assets"


### PR DESCRIPTION
## Purpose 
<!-- what/why -->
Get nightly code coverage run working in course builder again.

## Approach 
<!-- how -->
Make 3.2.6 default.
