### PR TITLE
Bel-5363 Fix Problem Getting Desired Count Dynamically

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -553,9 +553,11 @@ class ContainerComponent(pulumi.ComponentResource):
                                                                                                               name=f"{namespace}-unhealthy-host-metric-alarm",
                                                                                                               actions_enabled=True,
                                                                                                               ok_actions=[
-                                                                                                                  self.sns_topic_arn, self.strongmind_service_updates_topic_arn],
+                                                                                                                  self.sns_topic_arn,
+                                                                                                                  self.strongmind_service_updates_topic_arn],
                                                                                                               alarm_actions=[
-                                                                                                                  self.sns_topic_arn, self.strongmind_service_updates_topic_arn],
+                                                                                                                  self.sns_topic_arn,
+                                                                                                                  self.strongmind_service_updates_topic_arn],
                                                                                                               insufficient_data_actions=[],
                                                                                                               evaluation_periods=1,
                                                                                                               datapoints_to_alarm=1,
@@ -605,7 +607,6 @@ class ContainerComponent(pulumi.ComponentResource):
         if kwargs.get('use_cloudfront', True):
             self.setup_cloudfront(project, stack)
 
-
     def setup_cloudfront(self, project, stack):
         """Set up CloudFront distribution in front of the ALB"""
         if stack != "prod":
@@ -614,11 +615,10 @@ class ContainerComponent(pulumi.ComponentResource):
         else:
             name = project
             cdn_bucket = "strongmind-cdn-prod"
-            
+
         name = self.kwargs.get('namespace', name)
         domain = 'strongmind.com'
         full_name = f"{name}.{domain}"
-
 
         aws_east_1 = aws.Provider(qualify_component_name("aws-east-1", self.kwargs), region="us-east-1")
 
@@ -643,7 +643,7 @@ class ContainerComponent(pulumi.ComponentResource):
             zone_id=zone_id,
             content=self.cloudfront_cert.domain_validation_options.apply(
                 lambda opts: remove_trailing_period(opts[0]['resource_record_value'])
-            ),            
+            ),
             ttl=1,
             opts=pulumi.ResourceOptions(parent=self, depends_on=[self.cloudfront_cert], delete_before_replace=True)
         )
@@ -652,15 +652,15 @@ class ContainerComponent(pulumi.ComponentResource):
             qualify_component_name("cert_validation", self.kwargs),
             certificate_arn=self.cloudfront_cert.arn,
             validation_record_fqdns=[self.cloudfront_cert_validation_record.hostname],
-            opts=pulumi.ResourceOptions(provider=aws_east_1, parent=self, depends_on=[self.cloudfront_cert_validation_record], delete_before_replace=True)
+            opts=pulumi.ResourceOptions(provider=aws_east_1, parent=self,
+                                        depends_on=[self.cloudfront_cert_validation_record], delete_before_replace=True)
         )
-        
+
         cache_policy = aws.cloudfront.get_cache_policy(name="UseOriginCacheControlHeaders-QueryStrings")
         error_page_policy = aws.cloudfront.get_cache_policy(name="Managed-CachingOptimized")
         origin_request_policy = aws.cloudfront.get_origin_request_policy(name="Managed-AllViewer")
         response_header_policy = aws.cloudfront.get_response_headers_policy("5cc3b908-e619-4b99-88e5-2cf7f45965bd")
-        
-        
+
         self.cloudfront_distribution = aws.cloudfront.Distribution(
             qualify_component_name("cloudfront", self.kwargs),
             enabled=True,
@@ -682,7 +682,7 @@ class ContainerComponent(pulumi.ComponentResource):
                     origin_id=f"{cdn_bucket}.s3.us-west-2.amazonaws.com",
                 )
             ],
-            default_root_object="", 
+            default_root_object="",
             aliases=[full_name],
             viewer_certificate=aws.cloudfront.DistributionViewerCertificateArgs(
                 acm_certificate_arn=self.cloudfront_cert.arn,
@@ -753,4 +753,3 @@ class ContainerComponent(pulumi.ComponentResource):
             tags=self.tags,
             opts=pulumi.ResourceOptions(parent=self),
         )
-

--- a/deployment/src/tests/test_rails.py
+++ b/deployment/src/tests/test_rails.py
@@ -1008,3 +1008,12 @@ def describe_a_pulumi_rails_component():
         @pulumi.runtime.test
         def it_creates_secrets_with_the_namespace(sut, namespace):
             assert sut.secret.namespace == namespace
+
+
+    @pulumi.runtime.test
+    def it_sets_the_desired_web_count(sut):
+        def check_desired_count(args):
+            desired_count = args[0]
+            assert sut.current_desired_count == desired_count
+            return True
+        return pulumi.Output.all(sut.web_container.fargate_service.desired_count).apply(check_desired_count)


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-5363)

## Purpose 
<!-- what/why -->

- Dynamically retrieve the desired task count from AWS to ensure accurate scaling and resource allocation.
- Resolve edge cases in the namespace implementation that caused the initial implementation to fail, ensuring more robust and reliable workflows.


## Approach 
<!-- how -->
This pull request includes multiple changes to the `deployment/src/strongmind_deployment` and `deployment/src/tests` directories to improve the setup and testing of load balancers and ECS services. The most important changes include refactoring the `setup_load_balancer` method, adding error handling for ECS service discovery, and updating the test cases to reflect these changes.

### Refactoring and Code Cleanup:

* [`deployment/src/strongmind_deployment/container.py`](diffhunk://#diff-3f9fe040f3ced4b63cc35de46baf666b286eafbe36691e7301da52ed109e1de7L556-R560): Refactored the `setup_load_balancer` method to improve readability by splitting long lines into multiple lines. [[1]](diffhunk://#diff-3f9fe040f3ced4b63cc35de46baf666b286eafbe36691e7301da52ed109e1de7L556-R560) [[2]](diffhunk://#diff-3f9fe040f3ced4b63cc35de46baf666b286eafbe36691e7301da52ed109e1de7L655-L663)
* [`deployment/src/strongmind_deployment/container.py`](diffhunk://#diff-3f9fe040f3ced4b63cc35de46baf666b286eafbe36691e7301da52ed109e1de7L608): Removed unnecessary blank lines in the `setup_load_balancer` and `setup_cloudfront` methods. [[1]](diffhunk://#diff-3f9fe040f3ced4b63cc35de46baf666b286eafbe36691e7301da52ed109e1de7L608) [[2]](diffhunk://#diff-3f9fe040f3ced4b63cc35de46baf666b286eafbe36691e7301da52ed109e1de7L622) [[3]](diffhunk://#diff-3f9fe040f3ced4b63cc35de46baf666b286eafbe36691e7301da52ed109e1de7L756)

### Error Handling Improvements:

* [`deployment/src/strongmind_deployment/rails.py`](diffhunk://#diff-3eb9669fe4984ed39c322a7fe6d6da9b4894f2abb63d19c9ad36ee20d14630e7R10): Added import for `ClientError` from `botocore.exceptions` and implemented error handling for ECS service discovery, including logging for different error scenarios. [[1]](diffhunk://#diff-3eb9669fe4984ed39c322a7fe6d6da9b4894f2abb63d19c9ad36ee20d14630e7R10) [[2]](diffhunk://#diff-3eb9669fe4984ed39c322a7fe6d6da9b4894f2abb63d19c9ad36ee20d14630e7L121-R152)

### Test Updates:

* [`deployment/src/tests/test_rails.py`](diffhunk://#diff-797b96de81431db7c3be420b1dd557847c51f38fb9192d4a1cc9b87d16a51313L197-R207): Updated the `stubbed_ecs_client` method to include a failing standard case and a succeeding edge case for the `describe_services` call. [[1]](diffhunk://#diff-797b96de81431db7c3be420b1dd557847c51f38fb9192d4a1cc9b87d16a51313L197-R207) [[2]](diffhunk://#diff-797b96de81431db7c3be420b1dd557847c51f38fb9192d4a1cc9b87d16a51313L207-R217)
* [`deployment/src/tests/test_rails.py`](diffhunk://#diff-797b96de81431db7c3be420b1dd557847c51f38fb9192d4a1cc9b87d16a51313L1001-L1008): Removed the `it_sets_the_desired_web_count` test case to reflect changes in the desired count setup.
## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Added test for code changes
## Screenshots/Video
<!-- show before/after of the change if possible -->
Running a Pulumi Preview on prod for canvas-docker:
![image](https://github.com/user-attachments/assets/3b40eee3-77bd-44af-84de-0f65a1c405f0)
