### PR TITLE
Ignore testing entire containerization of app for dependabot changes

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -54,6 +54,7 @@ jobs:
     secrets: inherit
 
   test-docker:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest-m
     services:
       postgres:


### PR DESCRIPTION
Co-authored-by: Jason Tan <jason.tan@strongmind.com>

## Purpose 
It appears that dependabot never had access for the test-docker job. We've been
ignoring it and focusing mainly on the specs passing, so to me it makes sense
to just ignore the test-docker job if it is dependabot.

