### PR TITLE
BEL-4179: Implement scheduled scaling feature

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -355,9 +355,6 @@ class ContainerComponent(pulumi.ComponentResource):
             raise ValueError("pre_scale_time must be in 'HH:MM' format (24-hour)")
 
     def _validate_scheduled_scaling(self):
-        if self.scheduled_scaling and self.env_name != 'prod':
-            return
-
         if not self.scheduled_scaling:
             return
 

--- a/deployment/src/tests/test_container_autoscaling.py
+++ b/deployment/src/tests/test_container_autoscaling.py
@@ -1,5 +1,6 @@
 import random
 import re
+import os
 
 import pulumi
 import pytest
@@ -411,6 +412,7 @@ def describe_autoscaling():
         def describe_when_enabled():
             @pytest.fixture
             def component_kwargs(component_kwargs):
+                os.environ['ENVIRONMENT_NAME'] = 'prod'
                 component_kwargs["autoscale"] = True
                 component_kwargs["scheduled_scaling"] = True
                 component_kwargs["pre_scale_time"] = "06:00"


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-4179)

## Purpose 
<!-- what/why -->
This pull request introduces the implementation of a scheduled scaling feature in the `ContainerComponent` class, along with corresponding validation and testing. The most important changes include adding new parameters for scheduled scaling, implementing validation methods, and creating scheduled scaling actions. Additionally, tests have been added to ensure the correct functionality of this new feature.
## Approach 
<!-- how -->
### Scheduled Scaling Implementation:

* Added new parameters to the `__init__` method of the `ContainerComponent` class for scheduled scaling, including `scheduled_scaling`, `pre_scale_time`, `post_scale_time`, and `peak_min_capacity`. [[1]](diffhunk://#diff-3f9fe040f3ced4b63cc35de46baf666b286eafbe36691e7301da52ed109e1de7R42-R46) [[2]](diffhunk://#diff-3f9fe040f3ced4b63cc35de46baf666b286eafbe36691e7301da52ed109e1de7R87-R90)
* Implemented methods `_validate_time_format`, `_validate_scheduled_scaling`, and `_create_scheduled_scaling` to handle validation and creation of scheduled scaling actions.
* Updated the `autoscaling` method to include the creation of scheduled scaling actions when the feature is enabled.

### Validation Enhancements:

* Added `_validate_time_format` to ensure time strings are in the correct `HH:MM` format.
* Added `_validate_scheduled_scaling` to check that all required parameters for scheduled scaling are provided and valid.


## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Deployed locally using repo-dashboard
* Added new tests in `test_container_autoscaling.py` to verify the creation and correctness of scheduled scaling actions, including their names, cron expressions, timezones, and dependencies.
* Added validation tests to ensure that invalid time formats and missing parameters are correctly handled with appropriate error messages.


## Screenshots/Video
<!-- show before/after of the change if possible -->
![image](https://github.com/user-attachments/assets/6d746dd9-af2e-48e4-acb4-15d4d6939323)

