### PR TITLE
Bel-5424: support multiple cnames

### DIFF
--- a/deployment/requirements.txt
+++ b/deployment/requirements.txt
@@ -1,7 +1,7 @@
-pulumi
+pulumi==3.142.0
 pulumi-aws
 pulumi-awsx
-pulumi_cloudflare
+pulumi-cloudflare==5.49.1
 pulumi-random
 boto3
 

--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -728,8 +728,6 @@ class ContainerComponent(pulumi.ComponentResource):
             tags=self.tags,
             opts=pulumi.ResourceOptions(
                 provider=aws_east_1,
-                retain_on_delete=True,  # Don't delete the certificate if it's in use
-                delete_before_replace=False  # Create new certificate before deleting old one
             )
         )
 
@@ -776,8 +774,7 @@ class ContainerComponent(pulumi.ComponentResource):
             opts=pulumi.ResourceOptions(
                 provider=aws_east_1,
                 parent=self,
-                depends_on=self.cloudfront_cert_validation_records,
-                delete_before_replace=False  # Don't delete old validation until new one is ready
+                depends_on=self.cloudfront_cert_validation_records
             )
         )
 

--- a/deployment/src/tests/mocks.py
+++ b/deployment/src/tests/mocks.py
@@ -67,6 +67,7 @@ def get_pulumi_mocks(faker, fake_password=None, secret_string="{}"):
             if args.typ == "aws:acm/certificate:Certificate":
                 outputs["arn"] = f"arn:aws:acm:us-east-1:123456789012:certificate/{faker.uuid4()}"
                 outputs["domain_validation_options"] = [{
+                    "domain_name": outputs.get('domain_name', 'example.com'),
                     "resource_record_name": f"_validation.{outputs.get('domain_name', 'example.com')}.",
                     "resource_record_type": "CNAME",
                     "resource_record_value": f"{faker.word()}.acm-validations.aws."

--- a/deployment/src/tests/test_container.py
+++ b/deployment/src/tests/test_container.py
@@ -529,54 +529,65 @@ def describe_container():
             return pulumi.Output.all(sut.cloudfront_cert.arn).apply(check_region)
 
         @pulumi.runtime.test
-        def it_has_a_certificate_validation_record(sut):
-            assert sut.cloudfront_cert_validation_record
+        def it_has_certificate_validation_records(sut):
+            assert sut.cloudfront_cert_validation_records
 
         @pulumi.runtime.test
-        def it_sets_certificate_validation_record_name_from_options(sut):
-            def check_name(args):
-                record_name, validation_options = args
-                expected_name = validation_options[0]['resource_record_name']
-                assert record_name == expected_name
+        def it_sets_certificate_validation_record_names_from_options(sut):
+            def check_names(args):
+                records, validation_options = args
+                for i, option in enumerate(validation_options):
+                    assert records[i].name == option['resource_record_name']
 
             return pulumi.Output.all(
-                sut.cloudfront_cert_validation_record.name,
+                sut.cloudfront_cert_validation_records,
                 sut.cloudfront_cert.domain_validation_options
-            ).apply(check_name)
+            ).apply(check_names)
 
         @pulumi.runtime.test
-        def it_sets_certificate_validation_record_type_from_options(sut):
-            def check_type(args):
-                record_type, validation_options = args
-                expected_type = validation_options[0]['resource_record_type']
-                assert record_type == expected_type
+        def it_sets_certificate_validation_record_types_from_options(sut):
+            def check_types(args):
+                records, validation_options = args
+                for i, option in enumerate(validation_options):
+                    assert records[i].type == option['resource_record_type']
 
             return pulumi.Output.all(
-                sut.cloudfront_cert_validation_record.type,
+                sut.cloudfront_cert_validation_records,
                 sut.cloudfront_cert.domain_validation_options
-            ).apply(check_type)
+            ).apply(check_types)
 
         @pulumi.runtime.test
-        def it_sets_certificate_validation_record_content_from_options(sut):
-            def check_content(args):
-                record_content, validation_options = args
-                validation_value = validation_options[0]['resource_record_value']
-                # Remove trailing period if present
-                expected_content = validation_value[:-1] if validation_value.endswith('.') else validation_value
-                assert record_content == expected_content
+        def it_sets_certificate_validation_record_contents_from_options(sut):
+            def check_contents(args):
+                records, validation_options = args
+                for i, option in enumerate(validation_options):
+                    validation_value = option['resource_record_value']
+                    # Remove trailing period if present
+                    expected_content = validation_value[:-1] if validation_value.endswith('.') else validation_value
+                    assert records[i].content == expected_content
 
             return pulumi.Output.all(
-                sut.cloudfront_cert_validation_record.content,
+                sut.cloudfront_cert_validation_records,
                 sut.cloudfront_cert.domain_validation_options
-            ).apply(check_content)
+            ).apply(check_contents)
 
         @pulumi.runtime.test
-        def it_sets_certificate_validation_record_ttl(sut):
-            return assert_output_equals(sut.cloudfront_cert_validation_record.ttl, 1)
+        def it_sets_certificate_validation_record_ttls(sut):
+            def check_ttls(args):
+                records = args[0]
+                for record in records:
+                    assert record.ttl == 1
+
+            return pulumi.Output.all(sut.cloudfront_cert_validation_records).apply(check_ttls)
 
         @pulumi.runtime.test
-        def it_sets_certificate_validation_record_zone_id(sut):
-            return assert_output_equals(sut.cloudfront_cert_validation_record.zone_id, "b4b7fec0d0aacbd55c5a259d1e64fff5")
+        def it_sets_certificate_validation_record_zone_ids(sut):
+            def check_zone_ids(args):
+                records = args[0]
+                for record in records:
+                    assert record.zone_id == "b4b7fec0d0aacbd55c5a259d1e64fff5"
+
+            return pulumi.Output.all(sut.cloudfront_cert_validation_records).apply(check_zone_ids)
 
         @pulumi.runtime.test
         def it_has_certificate_validation(sut):
@@ -589,12 +600,13 @@ def describe_container():
         @pulumi.runtime.test
         def it_sets_certificate_validation_record_fqdns(sut):
             def check_fqdns(args):
-                validation_fqdns, record_hostname = args
-                assert validation_fqdns == [record_hostname]
+                validation_fqdns, records = args
+                record_hostnames = [record.hostname for record in records]
+                assert validation_fqdns == record_hostnames
 
             return pulumi.Output.all(
                 sut.cloudfront_cert_validation.validation_record_fqdns,
-                sut.cloudfront_cert_validation_record.hostname
+                sut.cloudfront_cert_validation_records
             ).apply(check_fqdns)
 
         @pulumi.runtime.test
@@ -602,36 +614,48 @@ def describe_container():
             def check_aliases(args):
                 aliases = args[0]
                 expected_alias = f"{stack}-{app_name}.strongmind.com" if stack != "prod" else f"{app_name}.strongmind.com"
-                assert aliases == [expected_alias]
+                assert expected_alias in aliases
 
             return pulumi.Output.all(sut.cloudfront_distribution.aliases).apply(check_aliases)
 
-        @pulumi.runtime.test
-        def it_configures_cloudfront_with_correct_origins(sut, stack):
-            def check_origins(args):
-                alb_origin, s3_origin, alb_dns_name = args
-                # Check ALB origin
-                assert alb_origin["domain_name"] == alb_dns_name
-                assert alb_origin["origin_id"] == alb_dns_name
-                assert alb_origin["custom_origin_config"]["origin_protocol_policy"] == "https-only"
-                assert alb_origin["custom_origin_config"]["origin_ssl_protocols"] == ["TLSv1.2"]
-                
-                # Check S3 origin
-                cdn_bucket = "strongmind-cdn-stage" if stack != "prod" else "strongmind-cdn-prod"
-                expected_s3_domain = f"{cdn_bucket}.s3.us-west-2.amazonaws.com"
-                assert s3_origin["domain_name"] == expected_s3_domain
-                assert s3_origin["origin_id"] == expected_s3_domain
+        def describe_with_additional_domain_aliases():
+            @pytest.fixture
+            def additional_domains():
+                return ["enrollment.strongmind.com"]
 
-            return pulumi.Output.all(
-                sut.cloudfront_distribution.origins[0],
-                sut.cloudfront_distribution.origins[1],
-                sut.load_balancer.dns_name
-            ).apply(check_origins)
-        
-        @pulumi.runtime.test
-        def it_configures_cloudfront_with_correct_cache_behavior(sut):
-            assert sut.cloudfront_distribution.default_cache_behavior
-            
+            @pytest.fixture
+            def component_kwargs(component_kwargs, additional_domains):
+                component_kwargs["additional_domain_aliases"] = additional_domains
+                return component_kwargs
+
+            @pulumi.runtime.test
+            def it_adds_domains_to_certificate_sans(sut, additional_domains):
+                return assert_outputs_equal(sut.cloudfront_cert.subject_alternative_names, additional_domains)
+
+            @pulumi.runtime.test
+            def it_adds_domains_to_cloudfront_aliases(sut, additional_domains, stack, app_name):
+                def check_aliases(args):
+                    aliases = args[0]
+                    expected_primary = f"{stack}-{app_name}.strongmind.com" if stack != "prod" else f"{app_name}.strongmind.com"
+                    assert expected_primary in aliases
+                    for domain in additional_domains:
+                        assert domain in aliases
+
+                return pulumi.Output.all(sut.cloudfront_distribution.aliases).apply(check_aliases)
+
+            @pulumi.runtime.test
+            def it_creates_cname_records_for_additional_domains(sut, additional_domains):
+                def check_cname_records(args):
+                    records = args[0]
+                    # Check we have records for all domains (primary + additional)
+                    assert len(records) == len(additional_domains) + 1
+                    # Check additional domain records
+                    additional_prefixes = [domain.split('.')[0] for domain in additional_domains]
+                    record_names = [record.name for record in records[1:]]  # Skip primary record
+                    assert sorted(additional_prefixes) == sorted(record_names)
+
+                return pulumi.Output.all(sut.cname_records).apply(check_cname_records)
+
         @pulumi.runtime.test
         def it_has_a_viewer_certificate(sut):
             assert sut.cloudfront_distribution.viewer_certificate


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-5424)

## Purpose 
<!-- what/why -->
Allow PRW to supoort multiple cnames.
This branch will create the cnames for the cloudfront distribution. 
Additional config is needed for the load balancer. 
## Approach 
<!-- how -->
**I had to pin pulumi to an older version because some tests are currently broken on the newest version -- will need to address in the not-so-distant-future**
This pull request introduces several enhancements and refactors to the `strongmind_deployment` module, particularly focusing on improving the handling of additional domain aliases in CloudFront distributions and their corresponding validation records. The changes also include updates to the associated tests to ensure the new functionalities are properly validated.

### Enhancements and Refactors:

* **Additional Domain Aliases:**
  * [`deployment/src/strongmind_deployment/container.py`](diffhunk://#diff-3f9fe040f3ced4b63cc35de46baf666b286eafbe36691e7301da52ed109e1de7R47-R50): Added support for an optional list of additional domain names to be included in the CloudFront distribution's certificate and aliases. These domains are added to the certificate's SAN and the CloudFront distribution's aliases. [[1]](diffhunk://#diff-3f9fe040f3ced4b63cc35de46baf666b286eafbe36691e7301da52ed109e1de7R47-R50) [[2]](diffhunk://#diff-3f9fe040f3ced4b63cc35de46baf666b286eafbe36691e7301da52ed109e1de7R720-R733) [[3]](diffhunk://#diff-3f9fe040f3ced4b63cc35de46baf666b286eafbe36691e7301da52ed109e1de7L730-L759) [[4]](diffhunk://#diff-3f9fe040f3ced4b63cc35de46baf666b286eafbe36691e7301da52ed109e1de7L770-R820) [[5]](diffhunk://#diff-3f9fe040f3ced4b63cc35de46baf666b286eafbe36691e7301da52ed109e1de7L822-R907)

* **Logging and Debugging:**
  * [`deployment/src/strongmind_deployment/container.py`](diffhunk://#diff-3f9fe040f3ced4b63cc35de46baf666b286eafbe36691e7301da52ed109e1de7L564-R568): Added a log statement to indicate whether scheduled scaling is enabled.

* **Certificate and DNS Record Management:**
  * [`deployment/src/strongmind_deployment/container.py`](diffhunk://#diff-3f9fe040f3ced4b63cc35de46baf666b286eafbe36691e7301da52ed109e1de7L730-L759): Refactored the creation of validation records to handle multiple domains and ensure that the certificate validation completes before creating the CloudFront distribution. [[1]](diffhunk://#diff-3f9fe040f3ced4b63cc35de46baf666b286eafbe36691e7301da52ed109e1de7L730-L759) [[2]](diffhunk://#diff-3f9fe040f3ced4b63cc35de46baf666b286eafbe36691e7301da52ed109e1de7L822-R907)

* **Test Updates:**
  * [`deployment/src/tests/test_container.py`](diffhunk://#diff-1c8f325fca8d22da7597aa980096ff7076fe936962232a0bafb5419712d4897dL532-R590): Updated tests to validate the creation of multiple certificate validation records and CNAME records for additional domains. Added new tests to ensure that additional domains are correctly added to the certificate SANs and CloudFront aliases. [[1]](diffhunk://#diff-1c8f325fca8d22da7597aa980096ff7076fe936962232a0bafb5419712d4897dL532-R590) [[2]](diffhunk://#diff-1c8f325fca8d22da7597aa980096ff7076fe936962232a0bafb5419712d4897dL592-R657)

These changes collectively enhance the flexibility and robustness of the deployment module, particularly in handling multiple domain aliases within CloudFront distributions.
## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Deployed from local and tested on repository-dashboard, got it to work by adding a wild card cert to the 443 listener.
Edit to trigger new run of failed actions
## Screenshots/Video
<!-- show before/after of the change if possible -->
