### PR TITLE
QTY-16970: Refine Unhealthy Host Metric Expression

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -665,7 +665,7 @@ class ContainerComponent(pulumi.ComponentResource):
                                                                                                                       id="e1",
                                                                                                                       label="UnhealthyHostRatio",
                                                                                                                       return_data=True,
-                                                                                                                      expression="IF(desired_tasks > 0, unhealthy_hosts / desired_tasks, 0)"
+                                                                                                                      expression="IF(desired_tasks >= 5, IF(desired_tasks > 0, unhealthy_hosts / desired_tasks, 0), IF(unhealthy_hosts >= 2, 1, 0))"
                                                                                                                   ),
                                                                                                                   aws.cloudwatch.MetricAlarmMetricQueryArgs(
                                                                                                                       id="unhealthy_hosts",

--- a/deployment/src/tests/test_container.py
+++ b/deployment/src/tests/test_container.py
@@ -977,7 +977,7 @@ def describe_container():
 
         @pulumi.runtime.test
         def it_triggers_based_on_mathematical_expression(sut):
-            return assert_output_equals(sut.unhealthy_host_metric_alarm.metric_queries[0].expression, "IF(desired_tasks > 0, unhealthy_hosts / desired_tasks, 0)")
+            return assert_output_equals(sut.unhealthy_host_metric_alarm.metric_queries[0].expression, "IF(desired_tasks >= 5, IF(desired_tasks > 0, unhealthy_hosts / desired_tasks, 0), IF(unhealthy_hosts >= 2, 1, 0))")
 
         @pulumi.runtime.test
         def it_checks_the_unit_as_a_count(sut):


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-16970)
[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-16971)

## Purpose 
<!-- what/why -->
Currently, alarms are triggered when 25% of containers are unhealthy. However, for applications that scale down to as few as 2 containers, a single unhealthy container can incorrectly trigger an alarm—even though the system automatically scales up and handles the load without intervention. To avoid unnecessary alerts in these low-capacity scenarios, we should only trigger an alarm if 2 or more containers are unhealthy when the total number is less than 5. For services with 5 or more containers, the existing 25% threshold remains appropriate.

## Approach 
<!-- how -->
Modify the unhealthy host metric alarm expression to apply different logic based on the number of containers:
	•	If fewer than 5 containers: alarm only if 2 or more are unhealthy
	•	If 5 or more containers: alarm if 25% or more are unhealthy

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Updated and Ran test

## Screenshots/Video
<!-- show before/after of the change if possible -->
N/A