### PR TITLE
(B) NXT-7030: Add Python 3.12 and 3.13 to supported runtimes

### DIFF
--- a/deployment/src/strongmind_deployment/lambda_component.py
+++ b/deployment/src/strongmind_deployment/lambda_component.py
@@ -36,6 +36,8 @@ class LambdaArgs:
             "python3.9",
             "python3.10",
             "python3.11",
+            "python3.12",
+            "python3.13"
         ]
         if self.runtime not in valid_runtimes:
             raise ValueError(f"Unsupported runtime: {self.runtime}")


### PR DESCRIPTION


[Link to Jira ticket](https://strongmind.atlassian.net/browse/TEAM-NUMBER)

## Purpose 
<!-- what/why -->
Deploy lambas for data team that include python 3.13
## Approach 
<!-- how -->
- Included Python 3.12 and 3.13 in the list of valid runtimes for LambdaArgs.
- Ensured compatibility with the latest Python versions for deployment.
## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->

## Screenshots/Video
<!-- show before/after of the change if possible -->
