### PR TITLE
(B) NXT-7108: Refine LambdaEnvVariables to accept Pulumi Outputs

### DIFF
--- a/deployment/src/strongmind_deployment/lambda_component.py
+++ b/deployment/src/strongmind_deployment/lambda_component.py
@@ -2,7 +2,7 @@ import pulumi
 import pulumi_aws as aws
 import os
 import json
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Union, Any
 
 from strongmind_deployment.operations import get_code_owner_team_name
 
@@ -61,7 +61,7 @@ class LambdaEnvVariables:
     Manages environment variables for the Lambda function.
     """
 
-    def __init__(self, variables: Optional[Dict[str, str]] = None):
+    def __init__(self, variables: Optional[Dict[str, Union[str, Any]]] = None):
         self.variables = variables or {}
         self.validate()
 
@@ -69,8 +69,9 @@ class LambdaEnvVariables:
         if not isinstance(self.variables, dict):
             raise ValueError("Environment variables must be provided as a dictionary")
         for key, value in self.variables.items():
-            if not isinstance(key, str) or not isinstance(value, str):
-                raise ValueError("Environment variable keys and values must be strings")
+            # Keys must be strings, values can be strings or Pulumi Outputs
+            if not isinstance(key, str) or not (isinstance(value, str) or hasattr(value, 'apply')):
+                raise ValueError("Environment variable keys must be strings and values must be strings or Pulumi Outputs")
 
 
 class LambdaComponent(pulumi.ComponentResource):


### PR DESCRIPTION


[Link to Jira ticket](https://strongmind.atlassian.net/browse/TEAM-NUMBER)

## Purpose 
<!-- what/why -->

## Approach 
<!-- how -->
- Updated the constructor of LambdaEnvVariables to allow values as Pulumi Outputs.
- Enhanced validation to ensure environment variable values can be strings or Pulumi Outputs.
- Improved type hinting for better clarity and maintainability.
## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->

## Screenshots/Video
<!-- show before/after of the change if possible -->
