### PR TITLE
(B) NXT-7108: Skip validation for Pulumi Outputs in LambdaEnvVariables

### DIFF
--- a/deployment/src/strongmind_deployment/lambda_component.py
+++ b/deployment/src/strongmind_deployment/lambda_component.py
@@ -66,6 +66,10 @@ class LambdaEnvVariables:
         self.validate()
 
     def validate(self):
+        # If the entire variables is a Pulumi Output, skip validation as it will be resolved at runtime
+        if hasattr(self.variables, 'apply'):
+            return
+            
         if not isinstance(self.variables, dict):
             raise ValueError("Environment variables must be provided as a dictionary")
         for key, value in self.variables.items():


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/NXT-7108)

## Purpose 
<!-- what/why -->
Working on the lambda component for datateam-scripts
Had to switch to using secrets manager for envs and now need to use pulumi output
## Approach 
<!-- how -->
- Added a check in the validate method to skip validation if variables are Pulumi Outputs.
- Ensures that the validation process accommodates runtime resolution of Pulumi Outputs.
## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->

## Screenshots/Video
<!-- show before/after of the change if possible -->
