### PR TITLE
(B) EXP1-6597: Enhance container component

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -51,6 +51,8 @@ class ContainerComponent(pulumi.ComponentResource):
         :key cross_account_assume_roles: A list of additional cross-account role ARNs that the container can assume. Defaults to [].
                                         Note: All containers automatically have access to assume the StrongmindStageAccessRole.
         :key cross_account_arn_role: The primary cross-account role ARN that the container can assume. Defaults to StrongmindStageAccessRole.
+        :key port_mappings: Custom port mappings for the container. If provided, overrides automatic port mapping logic.
+                           Should be a list of awsx.ecs.TaskDefinitionPortMappingArgs. Defaults to None.
         """
         super().__init__('strongmind:global_build:commons:container', name, None, opts)
         stack = pulumi.get_stack()
@@ -149,13 +151,16 @@ class ContainerComponent(pulumi.ComponentResource):
                 )
             )
 
-        port_mappings = None
-        if self.target_group is not None:
-            port_mappings = [awsx.ecs.TaskDefinitionPortMappingArgs(
-                container_port=self.container_port,
-                host_port=self.container_port,
-                target_group=self.target_group,
-            )]
+        # Use custom port mappings if provided, otherwise use automatic logic
+        port_mappings = kwargs.get('port_mappings', None)
+        if port_mappings is None:
+            # Automatic port mapping logic (existing behavior)
+            if self.target_group is not None:
+                port_mappings = [awsx.ecs.TaskDefinitionPortMappingArgs(
+                    container_port=self.container_port,
+                    host_port=self.container_port,
+                    target_group=self.target_group,
+                )]
 
         self.execution_role = aws.iam.Role(
             f"{self.namespace}-execution-role",

--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -151,10 +151,8 @@ class ContainerComponent(pulumi.ComponentResource):
                 )
             )
 
-        # Use custom port mappings if provided, otherwise use automatic logic
         port_mappings = kwargs.get('port_mappings', None)
         if port_mappings is None:
-            # Automatic port mapping logic (existing behavior)
             if self.target_group is not None:
                 port_mappings = [awsx.ecs.TaskDefinitionPortMappingArgs(
                     container_port=self.container_port,


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/EXP1-6597)

## Purpose 
<!-- what/why -->
This pull request adds support for custom port mappings to the container initialization logic, allowing users to explicitly specify port mapping configurations. The changes ensure that if custom port mappings are provided, they will override the automatic port mapping behavior.
This is needed so we can allow the dagster daemon and user-code services to communicate with each other within the vpc after having enabled the service discovery for each.
## Approach 
<!-- how -->
Container configuration improvements:

* Added a new `port_mappings` parameter to the `__init__` method of the `Container` class, allowing users to specify custom port mappings as a list of `awsx.ecs.TaskDefinitionPortMappingArgs`.
* Updated the port mapping logic in `__init__` to use the provided custom port mappings if available; otherwise, it falls back to the existing automatic port mapping logic.
## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->

## Screenshots/Video
<!-- show before/after of the change if possible -->
