### PR TITLE
Update CloudFront component

### DIFF
--- a/deployment/src/strongmind_deployment/cloudfront.py
+++ b/deployment/src/strongmind_deployment/cloudfront.py
@@ -147,7 +147,7 @@ class DistributionComponent(pulumi.ComponentResource):
           name=domain_validation_options[0].resource_record_name,
           type=domain_validation_options[0].resource_record_type,
           zone_id=zone_id,
-          value=resource_record_value,
+          content=resource_record_value,
           ttl=1,
           opts=pulumi.ResourceOptions(parent=self, depends_on=[self.cert]),
         )
@@ -169,6 +169,6 @@ class DistributionComponent(pulumi.ComponentResource):
         name=full_name,
         type='CNAME',
         zone_id=zone_id,
-        value=distribution_domain_name,
+        content=distribution_domain_name,
         ttl=1,
         )


### PR DESCRIPTION
- Adjusted resource properties to use `content` instead of `value` for DNS records.

[Link to Jira ticket](https://strongmind.atlassian.net/browse/TEAM-NUMBER)

## Purpose 
<!-- what/why -->
This pull request updates the way DNS record values are specified in the `cloudfront.py` deployment code, aligning with the expected parameter naming conventions in the underlying Pulumi provider.


## Approach 
<!-- how -->
DNS record creation updates:

* Changed the argument name from `value` to `content` when creating DNS records in both the certificate validation and CNAME creation logic in `cloudfront.py`. This ensures compatibility with the Pulumi provider's expected interface. [[1]](diffhunk://#diff-8e7c3a7c0c1061a4c7a03656dd58befb60ccf8df52caff07c000bbb3c596c3a6L150-R150) [[2]](diffhunk://#diff-8e7c3a7c0c1061a4c7a03656dd58befb60ccf8df52caff07c000bbb3c596c3a6L172-R172)