### PR TITLE
FSTN-4193: Add stop_timeout configuration support

### DIFF
--- a/deployment/src/strongmind_deployment/container.py
+++ b/deployment/src/strongmind_deployment/container.py
@@ -114,6 +114,7 @@ class ContainerComponent(pulumi.ComponentResource):
         self.post_scale_time = kwargs.get('post_scale_time')
         self.peak_min_capacity = kwargs.get('peak_min_capacity')
         self.use_nat_gateway = kwargs.get('use_nat_gateway', False)
+        self.stop_timeout = kwargs.get('stop_timeout')
 
         project = pulumi.get_project()
         self.namespace = kwargs.get('namespace', f"{project}-{stack}")
@@ -348,7 +349,8 @@ class ContainerComponent(pulumi.ComponentResource):
             essential=True,
             port_mappings=port_mappings,
             secrets=self.secrets,
-            environment=[{"name": k, "value": v} for k, v in self.env_vars.items()]
+            environment=[{"name": k, "value": v} for k, v in self.env_vars.items()],
+            stop_timeout=self.stop_timeout,
         )
 
         # Build task definition args - use 'containers' (plural) if we have sidecars, else 'container' (singular)

--- a/deployment/src/tests/test_container.py
+++ b/deployment/src/tests/test_container.py
@@ -1226,3 +1226,32 @@ def describe_container():
             @pulumi.runtime.test
             def it_adds_the_component_name_to_the_namespace(sut, namespace, component_name):
                 assert sut.namespace == f"{namespace}-{component_name}"
+
+    def describe_with_stop_timeout():
+        @pytest.fixture
+        def stop_timeout(faker):
+            return faker.random_int(min=1, max=120)
+
+        @pytest.fixture
+        def component_kwargs(component_kwargs, stop_timeout):
+            component_kwargs["stop_timeout"] = stop_timeout
+            return component_kwargs
+
+        @pulumi.runtime.test
+        def it_sets_stop_timeout_on_the_container(sut, stop_timeout):
+            def check_stop_timeout(args):
+                task_definition_dict = args[0]
+                container = task_definition_dict["container"]
+                assert container["stopTimeout"] == stop_timeout
+
+            return pulumi.Output.all(sut.fargate_service.task_definition_args).apply(check_stop_timeout)
+
+    def describe_without_stop_timeout():
+        @pulumi.runtime.test
+        def it_defaults_stop_timeout_to_none(sut):
+            def check_stop_timeout(args):
+                task_definition_dict = args[0]
+                container = task_definition_dict["container"]
+                assert container.get("stopTimeout") is None
+
+            return pulumi.Output.all(sut.fargate_service.task_definition_args).apply(check_stop_timeout)


### PR DESCRIPTION
[FSTN-4193](https://strongmind.atlassian.net/browse/FSTN-4193)

## Purpose

Add `stop_timeout` support to `ContainerComponent` so consumers can configure how long ECS waits (in seconds) between sending `SIGTERM` and `SIGKILL` when stopping a container. Without this, ECS defaults to 30 seconds, which may not be enough for apps that need a longer graceful shutdown window.

## Approach

- Extract `stop_timeout` from `kwargs` during `ContainerComponent.__init__`
- Pass it through to `TaskDefinitionContainerDefinitionArgs` which maps to the ECS `stopTimeout` container definition field
- No default is set — when omitted, ECS uses its built-in 30-second default

## Testing

- Added `describe_with_stop_timeout` test: sets a random `stop_timeout` value in `component_kwargs` and asserts it appears as `stopTimeout` in the serialized task definition
- Added `describe_without_stop_timeout` test: verifies that when `stop_timeout` is not provided, `stopTimeout` is `None` in the task definition

Run tests:
```bash
cd deployment/src && pytest tests/test_container.py -k "stop_timeout" -v
```

[FSTN-4193]: https://strongmind.atlassian.net/browse/FSTN-4193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ