### PR TITLE
QTY-19206: feat: enforce TLS 1.2+ on ALB HTTPS listener

### DIFF
--- a/deployment/src/strongmind_deployment/alb.py
+++ b/deployment/src/strongmind_deployment/alb.py
@@ -142,6 +142,7 @@ class Alb(pulumi.ComponentResource):
             port=443,
             certificate_arn=self.args.certificate_arn,
             protocol="HTTPS",
+            ssl_policy="ELBSecurityPolicy-TLS13-1-2-Res-PQ-2025-09",
             default_actions=[
                 lb.ListenerDefaultActionArgs(
                     type="fixed-response",


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/QTY-19206)

## Purpose

The ALB HTTPS listener in the shared `strongmind_deployment` library did not specify an `ssl_policy`, causing Pulumi to default to `ELBSecurityPolicy-2016-08` which allows TLS 1.0 and 1.1 connections. This change enforces TLS 1.2+ by setting the AWS-recommended security policy.

## Approach

Added `ssl_policy="ELBSecurityPolicy-TLS13-1-2-Res-PQ-2025-09"` to the HTTPS listener in `alb.py`. This is the AWS console default and recommended policy as of 2025, supporting TLS 1.2, TLS 1.3, and post-quantum key exchange.

## Testing

## Screenshots/Video

doc: [https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html)

N/A - infrastructure change

## Breaking Changes

None for modern clients. TLS 1.0 (removed from all browsers since 2020) and TLS 1.1 (removed from Chrome/Firefox/Edge, warning-only in Safari) will be rejected. Over 99% of web traffic already uses TLS 1.2+.

## Performance Impact

None

## Security Considerations

This change improves security posture by:
- Blocking deprecated TLS 1.0/1.1 protocols (RFC 8996)
- Enabling post-quantum cryptography support
- Aligning with AWS recommended security policy
- Meeting PCI DSS 4.0 requirements for TLS 1.2+

Made with [Cursor](https://cursor.com)