### PR TITLE
SKNK-8862: Make RDS Proxy require_tls configurable per app

### DIFF
--- a/deployment/src/strongmind_deployment/rails.py
+++ b/deployment/src/strongmind_deployment/rails.py
@@ -599,7 +599,7 @@ class RailsComponent(pulumi.ComponentResource):
             ],
             'role_arn': self.proxy_role.arn,
             'vpc_subnet_ids': vpc_subnet_ids,
-            'require_tls': False,
+            'require_tls': self.kwargs.get('require_tls', False),
             'tags': self.rds_tags,
         }
 


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/SKNK-8862)

## Purpose
Allow individual Rails apps to opt into requiring TLS on their RDS Proxy connections, supporting encryption-in-transit compliance requirements without forcing the change on all apps simultaneously.

## Approach
The `require_tls` setting on the RDS Proxy was hardcoded to `False`. This PR makes it configurable via a `require_tls` kwarg on `RailsComponent`, defaulting to `False` for backwards compatibility. Apps can opt in by passing `require_tls=True` in their Pulumi infrastructure config.

## Testing
- Verified the kwarg is read and passed through to the proxy args
- No behavior change for apps that don't pass the kwarg

## Screenshots/Video
<!-- placeholder -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)