### PR TITLE
VISDEV-9577: Add reusable PR accessibility workflow (axe-core + Playw…

### DIFF
--- a/.github/workflows/axe-accessibility-pr.yml
+++ b/.github/workflows/axe-accessibility-pr.yml
@@ -1,0 +1,208 @@
+name: Axe accessibility PR (reusable)
+
+# Example caller (in a consumer repo):
+# on:
+#   pull_request:
+#     branches: [main]
+# jobs:
+#   a11y:
+#     uses: strongmind/public-reusable-workflows/.github/workflows/axe-accessibility-pr.yml@main
+#     with:
+#       base-url: "http://127.0.0.1:3000"
+#       start-command: "bundle exec rails server -p 3000"
+#       base-sha: ${{ github.event.pull_request.base.sha }}
+#       head-sha: ${{ github.event.pull_request.head.sha }}
+#       pr-number: ${{ github.event.pull_request.number }}
+#       targets-path: ".github/axe_targets.json"
+#     secrets: inherit
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        required: false
+        type: string
+        default: ubuntu-latest
+      node-version:
+        required: false
+        type: string
+        default: "20"
+      base-url:
+        description: "Base URL to scan (must serve real HTML)."
+        required: true
+        type: string
+      start-command:
+        description: "Optional command to boot the app before scanning."
+        required: false
+        type: string
+        default: ""
+      ready-url:
+        description: "Optional URL to poll for readiness. Defaults to base-url + '/'."
+        required: false
+        type: string
+        default: ""
+      ready-timeout-seconds:
+        required: false
+        type: number
+        default: 120
+      changed-files:
+        description: "Optional newline-delimited changed files from caller."
+        required: false
+        type: string
+        default: ""
+      base-sha:
+        description: "Optional merge-base SHA for changed-file diff."
+        required: false
+        type: string
+        default: ""
+      head-sha:
+        description: "Optional head SHA for changed-file diff."
+        required: false
+        type: string
+        default: ""
+      pr-number:
+        description: "Optional PR number for sticky comment updates."
+        required: false
+        type: number
+        default: 0
+      targets-path:
+        description: "Caller-repo JSON mapping changed files to URL journeys."
+        required: true
+        type: string
+      post-comment:
+        required: false
+        type: boolean
+        default: true
+      annotations:
+        required: false
+        type: boolean
+        default: true
+      enforce:
+        description: "block or warn"
+        required: false
+        type: string
+        default: block
+
+jobs:
+  axe-runtime:
+    name: Runtime axe (wcag2a + wcag2aa)
+    runs-on: ${{ inputs.runner }}
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Resolve reusable workflow source
+        id: reusable-src
+        shell: bash
+        run: |
+          set -euo pipefail
+          WF_REF="${{ github.workflow_ref }}"
+          # Format: owner/repo/.github/workflows/file.yml@ref
+          REPO="${WF_REF%%/.github/workflows/*}"
+          REF="${WF_REF##*@}"
+          echo "repo=$REPO" >> "$GITHUB_OUTPUT"
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout caller repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout reusable workflow repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.reusable-src.outputs.repo }}
+          ref: ${{ steps.reusable-src.outputs.ref }}
+          path: .reusable-workflows
+          fetch-depth: 1
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: npm
+          cache-dependency-path: .reusable-workflows/scripts/ci/axe/package-lock.json
+
+      - name: Install axe / Playwright dependencies
+        working-directory: .reusable-workflows/scripts/ci/axe
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        working-directory: .reusable-workflows/scripts/ci/axe
+        run: npx playwright install --with-deps chromium
+
+      - name: Resolve changed files
+        shell: bash
+        run: |
+          set -euo pipefail
+          OUT="${{ runner.temp }}/changed_files.txt"
+          if [ -n "${{ inputs.changed-files }}" ]; then
+            printf "%s\n" "${{ inputs.changed-files }}" > "$OUT"
+          elif [ -n "${{ inputs.base-sha }}" ] && [ -n "${{ inputs.head-sha }}" ]; then
+            git diff --name-only "${{ inputs.base-sha }}" "${{ inputs.head-sha }}" > "$OUT" || true
+          else
+            echo "Missing changed-file context. Pass changed-files or base-sha/head-sha."
+            exit 1
+          fi
+          echo "Changed files: $(wc -l < "$OUT" | tr -d ' ')"
+
+      - name: Start app for scan (optional)
+        if: ${{ inputs.start-command != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          nohup bash -lc "${{ inputs.start-command }}" > "${{ runner.temp }}/axe-app.log" 2>&1 &
+          READY_URL="${{ inputs.ready-url }}"
+          if [ -z "$READY_URL" ]; then
+            READY_URL="${{ inputs.base-url }}/"
+          fi
+          READY_URL="${READY_URL%/}/"
+          for i in $(seq 1 ${{ inputs.ready-timeout-seconds }}); do
+            if curl -fsS "$READY_URL" >/dev/null 2>&1; then
+              echo "App ready: $READY_URL"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "App failed readiness check: $READY_URL"
+          echo "---- app log tail ----"
+          tail -n 100 "${{ runner.temp }}/axe-app.log" || true
+          exit 1
+
+      - name: Run axe PR check
+        working-directory: .reusable-workflows/scripts/ci/axe
+        env:
+          CHANGED_FILES_FILE: ${{ runner.temp }}/changed_files.txt
+          AXE_BASE_URL: ${{ inputs.base-url }}
+          AXE_OUTPUT_DIR: ${{ github.workspace }}/tmp/axe
+          AXE_TARGETS_PATH: ${{ startsWith(inputs.targets-path, '/') && inputs.targets-path || format('{0}/{1}', github.workspace, inputs.targets-path) }}
+          AXE_PR_NUMBER: ${{ inputs.pr-number }}
+          AXE_ENFORCE: warn
+          AXE_POST_COMMENT: ${{ inputs.post-comment }}
+          AXE_ANNOTATIONS: ${{ inputs.annotations }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm run a11y:pr
+
+      - name: Enforce accessibility policy
+        if: always()
+        env:
+          AXE_ENFORCE: ${{ inputs.enforce }}
+        run: |
+          if [ ! -f tmp/axe/axe-results.json ]; then
+            echo "Missing tmp/axe/axe-results.json"
+            exit 1
+          fi
+          node -e "
+            const fs = require('fs');
+            const j = JSON.parse(fs.readFileSync('tmp/axe/axe-results.json','utf8'));
+            let groups = 0;
+            for (const p of j.pages || []) {
+              for (const s of p.scans || []) groups += (s.violations || []).length;
+            }
+            const mode = (process.env.AXE_ENFORCE || 'block').toLowerCase();
+            if (groups > 0 && mode === 'block') {
+              console.error('Axe reported ' + groups + ' violation group(s). See PR comment and tmp/axe/axe-results.json.');
+              process.exit(1);
+            }
+            if (groups > 0) console.log('Axe reported ' + groups + ' violation group(s) (warning-only mode).');
+          "

--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,9 @@ temp.file
 my.secrets
 .DS_Store
 WARP.md
+
+# scripts/ci/axe (npm / Playwright)
+node_modules/
+
+# Local axe CI artifacts
+tmp/

--- a/scripts/ci/axe/axe_pr_check.mjs
+++ b/scripts/ci/axe/axe_pr_check.mjs
@@ -1,0 +1,315 @@
+#!/usr/bin/env node
+/**
+ * Runtime accessibility gate: axe-core + Playwright.
+ * Maps changed paths -> URL journeys from AXE_TARGETS_PATH JSON.
+ * Writes tmp/axe/axe-results.json + tmp/axe/summary.md; optional PR comment + annotations.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import AxeBuilder from "@axe-core/playwright";
+import picomatch from "picomatch";
+import { chromium } from "playwright";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+const TMP_AXE = process.env.AXE_OUTPUT_DIR
+  ? path.resolve(process.env.AXE_OUTPUT_DIR)
+  : path.join(REPO_ROOT, "tmp", "axe");
+const MARKER = process.env.AXE_STICKY_MARKER ?? "<!-- axe-a11y-report:sticky -->";
+
+const AXE_TAGS = ["wcag2a", "wcag2aa"];
+
+function readChangedFiles() {
+  const fileEnv = process.env.CHANGED_FILES_FILE;
+  if (fileEnv && fs.existsSync(fileEnv)) {
+    return fs
+      .readFileSync(fileEnv, "utf8")
+      .split(/\r?\n/)
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+  const raw = process.env.CHANGED_FILES ?? "";
+  return raw.split(/\r?\n/).map((s) => s.trim()).filter(Boolean);
+}
+
+function loadTargets() {
+  const override = process.env.AXE_TARGETS_PATH;
+  if (!override) {
+    throw new Error("AXE_TARGETS_PATH is required. Provide a changed-file -> URL mapping JSON.");
+  }
+  if (!fs.existsSync(override)) {
+    throw new Error(`AXE_TARGETS_PATH does not exist: ${override}`);
+  }
+  const data = JSON.parse(fs.readFileSync(override, "utf8"));
+  if (!Array.isArray(data.rules)) {
+    throw new Error("axe targets file: missing rules[]");
+  }
+  return data;
+}
+
+function firstMatchingRule(rules, changedPath) {
+  const posixPath = changedPath.split(path.sep).join("/");
+  for (const rule of rules) {
+    const globs = rule.globs;
+    if (!Array.isArray(globs)) continue;
+    for (const g of globs) {
+      const isMatch = picomatch(g, { dot: true })(posixPath);
+      if (isMatch) return rule;
+    }
+  }
+  return null;
+}
+
+function journeyForRule(rule) {
+  const j = rule.journey ?? rule.pathnames ?? rule.urls;
+  if (!Array.isArray(j) || j.length === 0) {
+    throw new Error(`axe_targets: rule missing journey/pathnames/urls: ${JSON.stringify(rule)}`);
+  }
+  return j.map((p) => (p.startsWith("/") ? p : `/${p}`));
+}
+
+function collectJourneys(changedFiles, rules) {
+  /** @type {Map<string, { key: string, paths: string[] }>} */
+  const byKey = new Map();
+  for (const file of changedFiles) {
+    const rule = firstMatchingRule(rules, file);
+    if (!rule) continue;
+    const journey = journeyForRule(rule);
+    const key = journey.join(">");
+    if (!byKey.has(key)) {
+      byKey.set(key, { key, paths: journey });
+    }
+  }
+  return [...byKey.values()];
+}
+
+function ensureDir(p) {
+  fs.mkdirSync(p, { recursive: true });
+}
+
+function githubEvent() {
+  const p = process.env.GITHUB_EVENT_PATH;
+  if (!p || !fs.existsSync(p)) return null;
+  return JSON.parse(fs.readFileSync(p, "utf8"));
+}
+
+async function githubApi(pathSuffix, init) {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) throw new Error("GITHUB_TOKEN required for API calls");
+  const repo = process.env.GITHUB_REPOSITORY;
+  if (!repo) throw new Error("GITHUB_REPOSITORY not set");
+  const url = `https://api.github.com/repos/${repo}${pathSuffix}`;
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+      ...(init?.headers ?? {}),
+    },
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`GitHub API ${pathSuffix} ${res.status}: ${text}`);
+  }
+  if (res.status === 204) return null;
+  return res.json();
+}
+
+async function upsertStickyComment(body) {
+  const ev = githubEvent();
+  const prFromEnv = Number.parseInt(process.env.AXE_PR_NUMBER ?? "", 10);
+  const pr = Number.isInteger(prFromEnv) && prFromEnv > 0 ? prFromEnv : (ev?.pull_request?.number ?? ev?.number);
+  if (!pr) {
+    console.warn("No pull_request in GITHUB_EVENT; skipping PR comment.");
+    return;
+  }
+  const comments = await githubApi(`/issues/${pr}/comments`, { method: "GET" });
+  const existing = Array.isArray(comments)
+    ? comments.find((c) => typeof c.body === "string" && c.body.includes(MARKER))
+    : null;
+  const fullBody = `${MARKER}\n${body}`;
+  if (existing?.id) {
+    await githubApi(`/issues/comments/${existing.id}`, {
+      method: "PATCH",
+      body: JSON.stringify({ body: fullBody }),
+    });
+  } else {
+    await githubApi(`/issues/${pr}/comments`, {
+      method: "POST",
+      body: JSON.stringify({ body: fullBody }),
+    });
+  }
+}
+
+function emitAnnotations(violations, baseUrl, pageUrl) {
+  const max = Number(process.env.AXE_ANNOTATION_LIMIT ?? "20");
+  let n = 0;
+  for (const v of violations) {
+    if (n >= max) break;
+    const nodes = v.nodes?.slice(0, 3) ?? [];
+    for (const node of nodes) {
+      if (n >= max) break;
+      const target = Array.isArray(node.target) ? node.target.join(" ") : String(node.target);
+      const msg = `${v.id}: ${v.help} — ${target}`.replace(/\r?\n/g, " ");
+      const safe = msg.slice(0, 4000);
+      console.log(`::warning file=${pageUrl.replace(baseUrl, "") || "/"}::${safe}`);
+      n++;
+    }
+  }
+}
+
+async function run() {
+  ensureDir(TMP_AXE);
+  const baseUrl = (process.env.AXE_BASE_URL ?? "http://127.0.0.1:4173").replace(/\/$/, "");
+  const changedFiles = readChangedFiles();
+  const { rules } = loadTargets();
+
+  const journeys =
+    changedFiles.length === 0
+      ? []
+      : collectJourneys(changedFiles, rules);
+
+  /** @type {{ meta: object, pages: object[] }} */
+  const out = {
+    meta: {
+      baseUrl,
+      changedFiles,
+      tags: AXE_TAGS,
+      journeys: journeys.map((j) => j.paths),
+      timestamp: new Date().toISOString(),
+    },
+    pages: [],
+  };
+
+  let totalViolations = 0;
+  let totalIncomplete = 0;
+
+  if (journeys.length === 0) {
+    const summary =
+      changedFiles.length === 0
+        ? "## Axe accessibility (runtime)\n\nNo changed files in this diff — **skipped** (nothing to map).\n"
+        : "## Axe accessibility (runtime)\n\nNo URL journeys matched changed files — **skipped**.\n";
+    fs.writeFileSync(path.join(TMP_AXE, "summary.md"), summary, "utf8");
+    fs.writeFileSync(path.join(TMP_AXE, "axe-results.json"), JSON.stringify(out, null, 2), "utf8");
+    if (process.env.AXE_POST_COMMENT === "true") {
+      await upsertStickyComment(summary);
+    }
+    console.log(summary);
+    return;
+  }
+
+  const browser = await chromium.launch({ headless: true });
+  try {
+    for (const { paths: journeyPaths } of journeys) {
+      const context = await browser.newContext();
+      const page = await context.newPage();
+      const pageResults = { journey: journeyPaths, scans: [] };
+
+      for (const pathname of journeyPaths) {
+        const url = `${baseUrl}${pathname}`;
+        await page.goto(url, { waitUntil: "networkidle", timeout: 60_000 });
+        const analysis = await new AxeBuilder({ page }).withTags(AXE_TAGS).analyze();
+        const { violations, incomplete, passes, ...rest } = analysis;
+        totalViolations += violations.length;
+        totalIncomplete += incomplete.length;
+
+        if (process.env.AXE_ANNOTATIONS !== "false") {
+          emitAnnotations(violations, baseUrl, url);
+        }
+
+        pageResults.scans.push({
+          url,
+          pathname,
+          violationCount: violations.length,
+          incompleteCount: incomplete.length,
+          passCount: passes?.length ?? 0,
+          violations,
+          incomplete,
+          raw: { ...rest, violations, incomplete, passes },
+        });
+      }
+
+      await context.close();
+      out.pages.push(pageResults);
+    }
+  } finally {
+    await browser.close();
+  }
+
+  fs.writeFileSync(path.join(TMP_AXE, "axe-results.json"), JSON.stringify(out, null, 2), "utf8");
+
+  const verdict =
+    totalViolations === 0
+      ? "**PASS** — no axe violations (wcag2a + wcag2aa)."
+      : `**FAIL** — ${totalViolations} axe violation group(s) reported.`;
+
+  const lines = [
+    "## Axe accessibility (runtime)",
+    "",
+    verdict,
+    "",
+    `**Base URL:** \`${baseUrl}\``,
+    `**Changed files (${changedFiles.length}):** ${changedFiles.length ? changedFiles.map((f) => `\`${f}\``).join(", ") : "—"}`,
+    "",
+    "### URLs scanned",
+  ];
+
+  for (const p of out.pages) {
+    lines.push(`- Journey: ${p.journey.map((x) => `\`${x}\``).join(" → ")}`);
+    for (const s of p.scans) {
+      lines.push(`  - \`${s.url}\` — ${s.violationCount} violation group(s), ${s.incompleteCount} incomplete`);
+    }
+  }
+
+  lines.push("", "### Findings");
+  if (totalViolations === 0) {
+    lines.push("_No violations._");
+  } else {
+    for (const p of out.pages) {
+      for (const s of p.scans) {
+        for (const v of s.violations) {
+          lines.push(`- **${v.id}** (${v.impact}): ${v.help}`);
+          if (v.helpUrl) lines.push(`  - Help: ${v.helpUrl}`);
+          const nodes = v.nodes?.slice(0, 5) ?? [];
+          for (const n of nodes) {
+            const t = Array.isArray(n.target) ? n.target.join(" ") : n.target;
+            const fx = n.failureSummary ? ` — ${n.failureSummary.replace(/\s+/g, " ").trim()}` : "";
+            lines.push(`  - \`${t}\`${fx}`);
+          }
+        }
+      }
+    }
+  }
+
+  if (totalIncomplete > 0) {
+    lines.push("", `_Note: ${totalIncomplete} incomplete check(s) — review raw \`tmp/axe/axe-results.json\`._`);
+  }
+
+  const summaryMd = lines.join("\n");
+  fs.writeFileSync(path.join(TMP_AXE, "summary.md"), summaryMd, "utf8");
+
+  if (process.env.AXE_POST_COMMENT === "true") {
+    await upsertStickyComment(summaryMd);
+  }
+
+  const sumFile = process.env.GITHUB_STEP_SUMMARY;
+  if (sumFile) {
+    fs.appendFileSync(sumFile, `\n${summaryMd}\n`);
+  }
+
+  console.log(summaryMd);
+
+  const enforce = (process.env.AXE_ENFORCE ?? "warn").toLowerCase();
+  if (totalViolations > 0 && enforce === "block") {
+    process.exitCode = 1;
+  }
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/scripts/ci/axe/package-lock.json
+++ b/scripts/ci/axe/package-lock.json
@@ -1,0 +1,98 @@
+{
+  "name": "axe-pr-check",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "axe-pr-check",
+      "devDependencies": {
+        "@axe-core/playwright": "^4.10.1",
+        "picomatch": "^4.0.2",
+        "playwright": "^1.49.1"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.1.tgz",
+      "integrity": "sha512-mKEfoUIB1MkVTht0BGZFXtSAEKXMJoDkyV5YZ9jbBmZCcWDz71tegNsdTkIN8zc/yMi5Gm2kx7Z5YQ9PfWNAWw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
+      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/scripts/ci/axe/package.json
+++ b/scripts/ci/axe/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "axe-pr-check",
+  "private": true,
+  "description": "CI-only: @axe-core/playwright + Playwright for runtime PR accessibility scans.",
+  "scripts": {
+    "a11y:pr": "node axe_pr_check.mjs"
+  },
+  "devDependencies": {
+    "@axe-core/playwright": "^4.10.1",
+    "picomatch": "^4.0.2",
+    "playwright": "^1.49.1"
+  }
+}


### PR DESCRIPTION
[VISDEV-9577](https://strongmind.atlassian.net/browse/VISDEV-9577)

## Purpose
Add a reusable GitHub Actions workflow that runs runtime accessibility checks on pull requests using axe-core (via @axe-core/playwright) and Playwright. Consumer repositories call this workflow and supply PR-scoped changed files plus a mapping file so scans target URLs related to touched paths.

## Approach
- Introduce `workflow_call` workflow `.github/workflows/axe-accessibility-pr.yml` that checks out the caller repo and separately checks out this reusable-workflows repo for centralized tooling under `.reusable-workflows/scripts/ci/axe`.
- Runner `scripts/ci/axe/axe_pr_check.mjs` maps changed files to URL journeys from a required caller `targets-path` JSON, runs wcag2a + wcag2aa scans, writes `tmp/axe/axe-results.json`, posts a sticky PR comment when `pr-number` is provided, and supports block vs warn enforcement.
- Pin Node dependencies with `package.json` / `package-lock.json` in `scripts/ci/axe/`. Ignore `node_modules/` and local `tmp/` via `.gitignore`.

## Testing
- Validated runner behavior locally: mapped changed file runs scan; unmatched mapping skips; missing `AXE_TARGETS_PATH` fails fast with a clear error.
- Parsed workflow YAML for structural validity.

## Screenshots/Video
N/A (CI-only change).

[VISDEV-9577]: https://strongmind.atlassian.net/browse/VISDEV-9577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ