### PR TITLE
Add GitHub Packages build arg for private gem auth

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -137,7 +137,9 @@ jobs:
           tags: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-args: BUNDLE_GEMS__CONTRIBSYS__COM=${{ secrets.BUNDLE_GEMS__CONTRIBSYS__COM }}
+          build-args: |
+            BUNDLE_GEMS__CONTRIBSYS__COM=${{ secrets.BUNDLE_GEMS__CONTRIBSYS__COM }}
+            BUNDLE_RUBYGEMS__PKG__GITHUB__COM=x-access-token:${{ secrets.GITHUB_TOKEN }}
 
   rspec-test:
     if: ${{ inputs.run-tests }}


### PR DESCRIPTION
## Summary

Pass `BUNDLE_RUBYGEMS__PKG__GITHUB__COM` as a Docker build arg alongside the existing Sidekiq Pro auth. This allows repos that consume private gems from GitHub Packages (e.g., `strongmind-agentcore-conversations`) to `bundle install` during Docker builds.

Uses `secrets.GITHUB_TOKEN` which is automatic — no org secret or PAT needed. The calling repo's token is passed through via `secrets: inherit`.

## Context

Central (StrongMind/central#7664) needs this to pull the `strongmind-agentcore-conversations` gem from `rubygems.pkg.github.com/StrongMind`.

## Test plan
- [ ] Central CI build passes after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)