### PR TITLE
fix: add GitHub Packages auth to rspec-test setup-ruby steps

### DIFF
--- a/.github/workflows/rspec-test.yml
+++ b/.github/workflows/rspec-test.yml
@@ -237,6 +237,7 @@ jobs:
           bundler-cache: 'true'
         env:
           BUNDLE_GEMS__CONTRIBSYS__COM: ${{ secrets.BUNDLE_GEMS__CONTRIBSYS__COM }}
+          BUNDLE_RUBYGEMS__PKG__GITHUB__COM: x-access-token:${{ secrets.GITHUB_TOKEN }}
 
       - name: Assets and DB setup
         if: ${{ steps.spec-check.outputs.specs-found == 'true' }}
@@ -286,6 +287,7 @@ jobs:
           bundler-cache: 'true'
         env:
           BUNDLE_GEMS__CONTRIBSYS__COM: ${{ secrets.BUNDLE_GEMS__CONTRIBSYS__COM }}
+          BUNDLE_RUBYGEMS__PKG__GITHUB__COM: x-access-token:${{ secrets.GITHUB_TOKEN }}
 
       - run: |
           ${{ inputs.bundle-no-assets }}


### PR DESCRIPTION
## Summary

- Add `BUNDLE_RUBYGEMS__PKG__GITHUB__COM` env var to both `setup-ruby` steps in `rspec-test.yml`
- This was already set in `docker-build.yml` as a Docker build arg but missing from the rspec workflow

## Why

Any repo that sources a gem from `rubygems.pkg.github.com` (e.g. `strongmind-agentcore-conversations`) fails with exit code 17 during `bundle install` when the gem version isn't cached. The rspec workflow couldn't authenticate to fetch new versions from GitHub Packages.

Discovered via StrongMind/central#7664 when bumping `strongmind-agentcore-conversations` from 0.2.3 to 0.2.4.